### PR TITLE
Rename application from mdns-manager to noroshi

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>mdns-manager</title>
+    <title>noroshi</title>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mdns-manager",
+  "name": "noroshi",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mdns-manager",
+      "name": "noroshi",
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
@@ -1579,6 +1579,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mdns-manager",
+  "name": "noroshi",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1955,24 +1955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "mdns-manager"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "dirs",
- "hostname",
- "if-addrs 0.13.4",
- "mdns-sd",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-opener",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
 name = "mdns-sd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2074,24 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "noroshi"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs",
+ "hostname",
+ "if-addrs 0.13.4",
+ "mdns-sd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-opener",
+ "thiserror 2.0.18",
+ "uuid",
+]
 
 [[package]]
 name = "num-conv"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mdns-manager"
+name = "noroshi"
 version = "0.1.0"
 description = "mDNS service advertisement manager"
 authors = ["you"]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 fn config_dir() -> Result<PathBuf, AppError> {
     let home =
         dirs::home_dir().ok_or_else(|| AppError::Config("Cannot find home directory".into()))?;
-    Ok(home.join(".mdns-manager"))
+    Ok(home.join(".noroshi"))
 }
 
 fn config_path() -> Result<PathBuf, AppError> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "mdns-manager",
+  "productName": "noroshi",
   "version": "0.1.0",
-  "identifier": "com.noroshi.mdns-manager",
+  "identifier": "com.noroshi.noroshi",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "mdns-manager",
+        "title": "noroshi",
         "width": 960,
         "height": 640
       }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,7 +20,7 @@ export function Layout({ activeTab, onTabChange, children }: Props) {
     <div className="min-h-screen bg-gray-50">
       <header className="border-b border-gray-200 bg-white px-6 py-4">
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-bold text-gray-900">mdns-manager</h1>
+          <h1 className="text-xl font-bold text-gray-900">noroshi</h1>
           {hostname && (
             <span className="group relative text-sm text-gray-500">
               Host: <span className="font-mono">{hostname}</span>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -29,7 +29,7 @@ export function SettingsView({ onImport }: Props) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "mdns-manager-config.json";
+      a.download = "noroshi-config.json";
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);


### PR DESCRIPTION
## Summary
This PR renames the application from "mdns-manager" to "noroshi" across all configuration files, source code, and user-facing strings.

## Key Changes
- Updated `tauri.conf.json`: Changed productName, identifier, and window title to "noroshi"
- Updated `package.json`: Changed package name to "noroshi"
- Updated `Cargo.toml`: Changed Rust package name to "noroshi"
- Updated configuration directory path from `.mdns-manager` to `.noroshi` in `src-tauri/src/config.rs`
- Updated HTML page title in `index.html` to "noroshi"
- Updated UI header text in `src/components/Layout.tsx` to display "noroshi"
- Updated exported config filename in `src/components/SettingsView.tsx` from "mdns-manager-config.json" to "noroshi-config.json"

## Notes
- The application description remains "mDNS service advertisement manager" as this describes the functionality
- All user-facing strings and identifiers have been consistently updated to reflect the new application name