### PR TITLE
Add project icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # noroshi
 
+<p align="center">
+  <img src="src-tauri/icons/icon.png" alt="noroshi icon" width="128" />
+</p>
+
 > Raise a smoke signal on .local — mDNS service publisher GUI
 
 **noroshi** (狼煙, "smoke signal") is a desktop application for managing and publishing mDNS (Bonjour / Avahi) services on your local network through a simple GUI.


### PR DESCRIPTION
## Summary
Added the noroshi project icon to the README to improve visual presentation and branding of the project documentation.

## Changes
- Added a centered icon image to the top of the README, displaying the noroshi application icon (128x128px)
- Icon is sourced from `src-tauri/icons/icon.png` with appropriate alt text

## Details
This is a documentation-only change that enhances the README's visual appeal by prominently featuring the application icon at the beginning of the document, following common open-source project conventions.