### PR TITLE
Update release.yml to remove macOS targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,6 @@ jobs:
         include:
           - platform: ubuntu-22.04
             rust_target: x86_64-unknown-linux-gnu
-          - platform: macos-latest
-            rust_target: aarch64-apple-darwin
-          - platform: macos-13
-            rust_target: x86_64-apple-darwin
           - platform: windows-latest
             rust_target: x86_64-pc-windows-msvc
 


### PR DESCRIPTION
Removed macOS targets from the release workflow.