### PR TITLE
Prepare 0.0.0-pre.3 for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,63 @@
 
 ## Status
 
-**Early development.** API and scope are subject to change.
+**Early development.** API and scope are subject to change. Pre-release versions are published to the `next` dist-tag — pin a specific version when installing.
+
+## Install
+
+```bash
+npm install noroshi@next
+```
+
+Requires Node 20+ for development; for the library itself any modern bundler / runtime that supports ES2022 + ESM works.
+
+## Quick start
+
+```ts
+import { generate, StubAdapter, type FewShotExample } from "noroshi";
+
+const grammar = `
+start:    greeting NAME
+greeting: "hello" | "hi" | "hey"
+NAME:     /[A-Za-z]+/
+`;
+
+const examples: FewShotExample[] = [
+  { input: "Greet Bob.",       output: "hello Bob" },
+  { input: "Say hi to Eve.",   output: "hi Eve"    },
+];
+
+const result = await generate({
+  task: "Greet Alice.",
+  grammar,
+  examples,
+  llm: new StubAdapter(() => "hello Alice"), // swap for FetchAdapter / WebLLM
+  validator: {
+    id: "regex",
+    validate: (s) =>
+      /^(hello|hi|hey) [A-Za-z]+$/.test(s.trim())
+        ? { ok: true }
+        : { ok: false, error: "must match `(hello|hi|hey) NAME`" },
+  },
+  retry: { maxAttempts: 3, includeErrorInPrompt: true },
+});
+
+console.log(result.output);     // → "hello Alice"
+console.log(result.attempts);   // → 1
+```
+
+For a real LLM, swap `StubAdapter` for one of the bundled adapters:
+
+```ts
+import { FetchAdapter } from "noroshi";
+
+const llm = new FetchAdapter({
+  endpoint: "http://localhost:11434/v1", // Ollama, llama-server, vLLM, …
+  model: "qwen2.5:1.5b",
+});
+```
+
+A WebLLM-driven browser example (with grammar injection, retry-with-feedback, and a p5.js DSL transpiler) lives under `examples/creative-coding-p5js/` in the [source repo](https://github.com/velocitylabo/noroshi).
 
 ## Why
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noroshi",
-  "version": "0.0.0-pre.2",
+  "version": "0.0.0-pre.3",
   "description": "Grammar Prompting for browser LLMs — constrained DSL output without fine-tuning",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,11 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx examples/creative-coding-p5js/test.ts && tsx examples/creative-coding-p5js/test-fetch.ts && tsx examples/creative-coding-p5js/test-safety.ts"
+    "test": "tsx examples/creative-coding-p5js/test.ts && tsx examples/creative-coding-p5js/test-fetch.ts && tsx examples/creative-coding-p5js/test-safety.ts",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "keywords": [
     "llm",


### PR DESCRIPTION
## Summary

- Bump `0.0.0-pre.2` → `0.0.0-pre.3` (next in the existing pre-release lane on npm; name was taken by piroz on 2026-05-09 with pre.1 / pre.2 already shipped).
- `prepublishOnly` chains `typecheck` + `npm test` (32 assertions) + `build` so a future `npm publish` can't ship a broken tarball.
- `engines: { node: ">=20" }` matches the CI matrix.
- README adds an Install section (`npm install noroshi@next`) and a Quick start showing `StubAdapter` + a regex `Validator` + retry-with-feedback, plus a `FetchAdapter` swap-in for local Ollama.

## Verification

- `npm publish --dry-run`: 14.7 kB packed / 41.9 kB unpacked / 31 files, all gates green.
- 32 / 32 assertions pass across the three suites.

## Publish (manual, after merge)

```bash
npm login
npm publish --tag next
```

`publishConfig.tag = "next"` appears to be ignored by current npm (previous `0.0.0-pre.*` versions all landed on the `latest` dist-tag), so `--tag next` is required explicitly to keep `latest` from drifting to a pre-release.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (32 assertions)
- [x] `npm publish --dry-run`