### PR TITLE
Add GrammarAwareRanker for best-of-N self-consistency

### DIFF
--- a/examples/creative-coding-p5js/harness.mjs
+++ b/examples/creative-coding-p5js/harness.mjs
@@ -483,6 +483,7 @@ export async function generate(opts) {
   let lastError;
   let lastCandidates;
   let lastValidation;
+  let lastOutput = "";
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const prompt = buildPrompt({
@@ -502,8 +503,9 @@ export async function generate(opts) {
 
     if (opts.onCandidates) opts.onCandidates(candidates, attempt);
 
-    const picked = _pick(candidates, opts);
+    const picked = await _pick(candidates, opts);
     lastValidation = picked.validation;
+    lastOutput = picked.output;
 
     if (!opts.validator) {
       return { output: picked.output, attempts, candidates: n > 1 ? candidates : undefined };
@@ -520,7 +522,7 @@ export async function generate(opts) {
   }
 
   return {
-    output: lastCandidates?.[0] ?? "",
+    output: lastOutput,
     attempts,
     candidates: lastCandidates,
     validation: lastValidation,
@@ -533,14 +535,42 @@ async function _sample(llm, prompt, n, opts) {
   return Promise.all(Array.from({ length: n }, () => llm.complete(prompt, opts)));
 }
 
-function _pick(candidates, opts) {
+async function _pick(candidates, opts) {
   if (!opts.validator) return { output: candidates[0] ?? "" };
-  for (const c of candidates) {
-    const v = opts.validator.validate(c);
-    if (v.ok) return { output: c, validation: v };
+
+  const validations = candidates.map((c) => opts.validator.validate(c));
+
+  if (opts.selfConsistency?.ranker) {
+    const scores = await opts.selfConsistency.ranker.rank(candidates, { validations });
+    let bestIdx = 0;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < candidates.length; i++) {
+      const s = scores[i] ?? Number.POSITIVE_INFINITY;
+      if (s < bestScore) { bestScore = s; bestIdx = i; }
+    }
+    return { output: candidates[bestIdx] ?? "", validation: validations[bestIdx] };
   }
-  const fallback = candidates[0] ?? "";
-  return { output: fallback, validation: opts.validator.validate(fallback) };
+
+  for (let i = 0; i < candidates.length; i++) {
+    if (validations[i]?.ok) return { output: candidates[i] ?? "", validation: validations[i] };
+  }
+  return { output: candidates[0] ?? "", validation: validations[0] };
+}
+
+// Mirrors src/rankers/grammar.ts. Score: valid → 0; invalid w/ offset →
+// max(1, len - errorOffset); no validation → length.
+export class GrammarAwareRanker {
+  constructor() { this.id = "grammar-aware"; }
+  async rank(candidates, context) {
+    const validations = context?.validations;
+    return candidates.map((c, i) => {
+      const v = validations?.[i];
+      if (!v) return c.length;
+      if (v.ok) return 0;
+      const offset = typeof v.errorOffset === "number" ? v.errorOffset : 0;
+      return Math.max(1, c.length - offset);
+    });
+  }
 }
 
 // --- validator wrapper that conforms to the noroshi Validator interface ---

--- a/examples/creative-coding-p5js/test-ranker.ts
+++ b/examples/creative-coding-p5js/test-ranker.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for GrammarAwareRanker.
+ *
+ * Two layers:
+ *  (1) Direct rank() call — assert score ordering: valid < deep-fail < shallow-fail.
+ *  (2) End-to-end through generate() with StubAdapter returning N candidates,
+ *      assert that the ranker drives the final pick:
+ *        - all-invalid set      → deepest parse wins
+ *        - mixed valid/invalid  → valid wins
+ *
+ * Run: `npx tsx examples/creative-coding-p5js/test-ranker.ts`
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  generate,
+  StubAdapter,
+  GrammarAwareRanker,
+} from "../../src/index.js";
+
+import { CreativeCodingValidator } from "./validator.js";
+import { FEW_SHOTS } from "./examples.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GRAMMAR = readFileSync(resolve(HERE, "grammar.lark"), "utf8");
+
+const validator = new CreativeCodingValidator();
+const ranker = new GrammarAwareRanker();
+
+let pass = 0;
+let fail = 0;
+
+function ok(label: string): void {
+  console.log(`ok: ${label}`);
+  pass++;
+}
+
+function bad(label: string, why: string): void {
+  console.error(`FAIL: ${label} — ${why}`);
+  fail++;
+}
+
+// ---- (1) Direct rank() ----
+
+const VALID = "background black";
+// "flubber" is unknown → lex fails at offset 0 → shallow.
+const SHALLOW_FAIL = "flubber background black";
+// Lex passes, parser succeeds through `background black` (16 chars),
+// then `circle` consumes 3 expressions and trips on "a" (unknown identifier
+// inside expression — actually lex still rejects "a" first because "a" is
+// not in VAR/FUNC/KEYWORD/COLOR. Tweak: use `bad_kw` to force a parse-time
+// failure deep in the input.
+//
+// Cleaner deep-fail: a well-formed shape statement followed by a malformed
+// rgb literal — lex passes everything, parser fails partway through rgb(...).
+const DEEP_FAIL = "background black\nfill rgb(1, 2)"; // rgb expects 3 args, fails near offset 30
+
+{
+  const cands = [SHALLOW_FAIL, DEEP_FAIL, VALID];
+  const validations = cands.map((c) => validator.validate(c));
+  const scores = await ranker.rank(cands, { validations });
+  const [sShallow, sDeep, sValid] = scores;
+
+  if (sValid === 0) ok("rank: valid candidate scores 0");
+  else bad("rank: valid scores 0", `got ${sValid}`);
+
+  if (typeof sDeep === "number" && typeof sShallow === "number" && sDeep < sShallow) {
+    ok(`rank: deeper fail beats shallow fail (deep=${sDeep} < shallow=${sShallow})`);
+  } else {
+    bad("rank: deep < shallow", `deep=${sDeep} shallow=${sShallow}`);
+  }
+
+  if (typeof sValid === "number" && typeof sDeep === "number" && sValid < sDeep) {
+    ok(`rank: valid beats deep fail (${sValid} < ${sDeep})`);
+  } else {
+    bad("rank: valid < deep", `valid=${sValid} deep=${sDeep}`);
+  }
+}
+
+// ---- (2) End-to-end through generate() ----
+
+function llmWith(candidates: string[]): StubAdapter {
+  // StubAdapter responder returns the array as the N-sample bank.
+  return new StubAdapter(() => candidates);
+}
+
+// 2a) All N candidates invalid; deepest parse must be chosen.
+{
+  const result = await generate({
+    task: "force best-of-N selection",
+    grammar: GRAMMAR,
+    examples: FEW_SHOTS,
+    llm: llmWith([SHALLOW_FAIL, DEEP_FAIL, "more_nonsense"]),
+    validator,
+    selfConsistency: { n: 3, ranker },
+  });
+  if (result.output === DEEP_FAIL) {
+    ok("best-of-N (all invalid): deepest parse wins");
+  } else {
+    bad("best-of-N all invalid", `picked "${result.output.slice(0, 40)}", wanted DEEP_FAIL`);
+  }
+}
+
+// 2b) Mixed set: valid candidate must win even when it isn't the first one
+// emitted (this is the regression noroshi's old "first-valid wins" code
+// would have caught too, but we want to assert the ranker path agrees).
+{
+  const result = await generate({
+    task: "mixed set",
+    grammar: GRAMMAR,
+    examples: FEW_SHOTS,
+    llm: llmWith([SHALLOW_FAIL, VALID, DEEP_FAIL]),
+    validator,
+    selfConsistency: { n: 3, ranker },
+  });
+  if (result.output === VALID && result.validation?.ok) {
+    ok("best-of-N (mixed): valid candidate wins regardless of position");
+  } else {
+    bad("best-of-N mixed", `picked "${result.output.slice(0, 40)}" valid=${result.validation?.ok}`);
+  }
+}
+
+// 2c) Without a ranker, the old first-valid behaviour still holds.
+{
+  const result = await generate({
+    task: "first-valid baseline",
+    grammar: GRAMMAR,
+    examples: FEW_SHOTS,
+    llm: llmWith([SHALLOW_FAIL, DEEP_FAIL, VALID]),
+    validator,
+    selfConsistency: { n: 3 }, // no ranker
+  });
+  if (result.output === VALID) {
+    ok("no-ranker baseline: first-valid still wins");
+  } else {
+    bad("no-ranker baseline", `picked "${result.output.slice(0, 40)}"`);
+  }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/examples/creative-coding-p5js/validator.ts
+++ b/examples/creative-coding-p5js/validator.ts
@@ -42,7 +42,9 @@ interface Tok {
   pos: number;
 }
 
-function lex(src: string): Tok[] | { error: string } {
+interface LexError { error: string; errorOffset: number }
+
+function lex(src: string): Tok[] | LexError {
   const toks: Tok[] = [];
   let i = 0;
   while (i < src.length) {
@@ -84,10 +86,10 @@ function lex(src: string): Tok[] | { error: string } {
       else if (COLOR_NAMES.has(w)) toks.push({ kind: "color", value: w, pos: start });
       else if (VARS.has(w)) toks.push({ kind: "var", value: w, pos: start });
       else if (FUNCS.has(w)) toks.push({ kind: "func", value: w, pos: start });
-      else return { error: `unknown identifier "${w}" at offset ${start}` };
+      else return { error: `unknown identifier "${w}" at offset ${start}`, errorOffset: start };
       continue;
     }
-    return { error: `unexpected character "${c}" at offset ${i}` };
+    return { error: `unexpected character "${c}" at offset ${i}`, errorOffset: i };
   }
   return toks;
 }
@@ -106,10 +108,25 @@ const ARITY: Record<string, number> = {
 
 class Parser {
   private p = 0;
+  private lastPos = 0;
   constructor(private readonly toks: Tok[]) {}
 
   peek(o = 0): Tok | undefined { return this.toks[this.p + o]; }
-  eat(): Tok | undefined { return this.toks[this.p++]; }
+  eat(): Tok | undefined {
+    const t = this.toks[this.p++];
+    if (t) this.lastPos = t.pos;
+    return t;
+  }
+
+  /** Build a failure with errorOffset filled from the supplied pos or the
+   *  most recently consumed token's position. */
+  private fail(error: string, posHint?: number): ValidationResult {
+    return {
+      ok: false,
+      error,
+      errorOffset: typeof posHint === "number" ? posHint : this.lastPos,
+    };
+  }
 
   parse(): ValidationResult {
     while (this.p < this.toks.length) {
@@ -132,7 +149,7 @@ class Parser {
   braceBlock(): ValidationResult {
     const open = this.eat();
     if (!open || open.kind !== "lbrace") {
-      return { ok: false, error: `expected "{" at offset ${open?.pos ?? -1}` };
+      return this.fail(`expected "{" at offset ${open?.pos ?? -1}`, open?.pos);
     }
     while (this.peek() && this.peek()!.kind !== "rbrace") {
       const r = this.stmt();
@@ -140,16 +157,16 @@ class Parser {
     }
     const close = this.eat();
     if (!close || close.kind !== "rbrace") {
-      return { ok: false, error: "unbalanced { ... } block" };
+      return this.fail("unbalanced { ... } block");
     }
     return { ok: true };
   }
 
   stmt(): ValidationResult {
     const t = this.peek();
-    if (!t) return { ok: false, error: "unexpected end of input" };
+    if (!t) return this.fail("unexpected end of input");
     if (t.kind !== "kw") {
-      return { ok: false, error: `expected a statement keyword at offset ${t.pos}, got "${t.value}"` };
+      return this.fail(`expected a statement keyword at offset ${t.pos}, got "${t.value}"`, t.pos);
     }
     this.eat();
     switch (t.value) {
@@ -163,7 +180,7 @@ class Parser {
       case "pop":
         return { ok: true };
       case "rgb":
-        return { ok: false, error: `"rgb" cannot start a statement (use it after fill/stroke/background)` };
+        return this.fail(`"rgb" cannot start a statement (use it after fill/stroke/background)`, t.pos);
       case "rotate":
       case "translate":
       case "circle":
@@ -180,38 +197,38 @@ class Parser {
       case "repeat": {
         const count = this.eat();
         if (!count || count.kind !== "num" || !/^\d+$/.test(count.value)) {
-          return { ok: false, error: `repeat expects a positive integer at offset ${count?.pos ?? -1}` };
+          return this.fail(`repeat expects a positive integer at offset ${count?.pos ?? -1}`, count?.pos);
         }
         return this.braceBlock();
       }
       case "setup":
       case "tick":
-        return { ok: false, error: `"${t.value}" block is only valid at the top level` };
+        return this.fail(`"${t.value}" block is only valid at the top level`, t.pos);
     }
-    return { ok: false, error: `unhandled keyword "${t.value}"` };
+    return this.fail(`unhandled keyword "${t.value}"`, t.pos);
   }
 
   color(): ValidationResult {
     const t = this.peek();
-    if (!t) return { ok: false, error: "expected color" };
+    if (!t) return this.fail("expected color");
     if (t.kind === "color") { this.eat(); return { ok: true }; }
     if (t.kind === "kw" && t.value === "rgb") {
       this.eat();
       const lp = this.eat();
-      if (!lp || lp.kind !== "lparen") return { ok: false, error: `rgb expects "(" at offset ${lp?.pos ?? -1}` };
+      if (!lp || lp.kind !== "lparen") return this.fail(`rgb expects "(" at offset ${lp?.pos ?? -1}`, lp?.pos);
       for (let k = 0; k < 3; k++) {
         const r = this.expr();
         if (!r.ok) return r;
         if (k < 2) {
           const c = this.eat();
-          if (!c || c.kind !== "comma") return { ok: false, error: `rgb expects "," at offset ${c?.pos ?? -1}` };
+          if (!c || c.kind !== "comma") return this.fail(`rgb expects "," at offset ${c?.pos ?? -1}`, c?.pos);
         }
       }
       const rp = this.eat();
-      if (!rp || rp.kind !== "rparen") return { ok: false, error: `rgb expects ")" at offset ${rp?.pos ?? -1}` };
+      if (!rp || rp.kind !== "rparen") return this.fail(`rgb expects ")" at offset ${rp?.pos ?? -1}`, rp?.pos);
       return { ok: true };
     }
-    return { ok: false, error: `expected color name or rgb(...) at offset ${t.pos}, got "${t.value}"` };
+    return this.fail(`expected color name or rgb(...) at offset ${t.pos}, got "${t.value}"`, t.pos);
   }
 
   /** expr → term (("+"|"-") term)* */
@@ -240,18 +257,18 @@ class Parser {
 
   factor(): ValidationResult {
     const t = this.eat();
-    if (!t) return { ok: false, error: "expected expression, got end of input" };
+    if (!t) return this.fail("expected expression, got end of input");
     if (t.kind === "num" || t.kind === "var") return { ok: true };
     if (t.kind === "lparen") {
       const r = this.expr();
       if (!r.ok) return r;
       const rp = this.eat();
-      if (!rp || rp.kind !== "rparen") return { ok: false, error: `expected ")" at offset ${rp?.pos ?? -1}` };
+      if (!rp || rp.kind !== "rparen") return this.fail(`expected ")" at offset ${rp?.pos ?? -1}`, rp?.pos);
       return { ok: true };
     }
     if (t.kind === "func") {
       const lp = this.eat();
-      if (!lp || lp.kind !== "lparen") return { ok: false, error: `${t.value} expects "(" at offset ${lp?.pos ?? -1}` };
+      if (!lp || lp.kind !== "lparen") return this.fail(`${t.value} expects "(" at offset ${lp?.pos ?? -1}`, lp?.pos);
       // at least one arg
       const r = this.expr();
       if (!r.ok) return r;
@@ -261,10 +278,10 @@ class Parser {
         if (!rk.ok) return rk;
       }
       const rp = this.eat();
-      if (!rp || rp.kind !== "rparen") return { ok: false, error: `${t.value} expects ")" at offset ${rp?.pos ?? -1}` };
+      if (!rp || rp.kind !== "rparen") return this.fail(`${t.value} expects ")" at offset ${rp?.pos ?? -1}`, rp?.pos);
       return { ok: true };
     }
-    return { ok: false, error: `expected number, variable, function call, or "(...)" at offset ${t.pos}, got "${t.value}"` };
+    return this.fail(`expected number, variable, function call, or "(...)" at offset ${t.pos}, got "${t.value}"`, t.pos);
   }
 }
 
@@ -273,7 +290,9 @@ export class CreativeCodingValidator implements Validator {
 
   validate(src: string): ValidationResult {
     const toks = lex(src);
-    if (!Array.isArray(toks)) return { ok: false, error: toks.error };
+    if (!Array.isArray(toks)) {
+      return { ok: false, error: toks.error, errorOffset: toks.errorOffset };
+    }
     return new Parser(toks).parse();
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx examples/creative-coding-p5js/test.ts && tsx examples/creative-coding-p5js/test-fetch.ts && tsx examples/creative-coding-p5js/test-safety.ts",
+    "test": "tsx examples/creative-coding-p5js/test.ts && tsx examples/creative-coding-p5js/test-fetch.ts && tsx examples/creative-coding-p5js/test-safety.ts && tsx examples/creative-coding-p5js/test-ranker.ts",
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,5 @@ export { FetchAdapter } from "./adapters/fetch.js";
 export type { FetchAdapterOptions } from "./adapters/fetch.js";
 
 export { cleanCompletion } from "./util/clean.js";
+
+export { GrammarAwareRanker } from "./rankers/grammar.js";

--- a/src/noroshi.ts
+++ b/src/noroshi.ts
@@ -20,6 +20,7 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   let lastError: string | undefined;
   let lastCandidates: string[] | undefined;
   let lastValidation: ValidationResult | undefined;
+  let lastOutput = "";
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const prompt = buildPrompt({
@@ -35,8 +36,9 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
     attempts += candidates.length;
     lastCandidates = candidates;
 
-    const picked = pick(candidates, opts);
+    const picked = await pick(candidates, opts);
     lastValidation = picked.validation;
+    lastOutput = picked.output;
 
     if (!opts.validator) {
       return {
@@ -57,8 +59,10 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
     lastError = picked.validation && !picked.validation.ok ? picked.validation.error : "unknown";
   }
 
+  // Out of retries: surface the best candidate the ranker (or first-valid)
+  // picked on the final attempt, not just candidate #0.
   return {
-    output: lastCandidates?.[0] ?? "",
+    output: lastOutput,
     attempts,
     candidates: lastCandidates,
     validation: lastValidation,
@@ -85,32 +89,30 @@ interface Picked {
   validation?: ValidationResult;
 }
 
-function pick(candidates: string[], opts: GenerateOptions): Picked {
+async function pick(candidates: string[], opts: GenerateOptions): Promise<Picked> {
   if (!opts.validator) {
     return { output: candidates[0] ?? "" };
   }
 
+  const validations = candidates.map((c) => opts.validator!.validate(c));
+
   if (opts.selfConsistency?.ranker) {
-    // Custom ranker — pick the lowest score that also validates.
-    // (Async ranker integration would require restructuring this helper to
-    // async; deferred until ranker plugin is needed.)
-    // For now: validate each, keep valid set, return first.
-    const valid = candidates
-      .map((c) => ({ c, v: opts.validator!.validate(c) }))
-      .filter((x) => x.v.ok);
-    if (valid.length > 0) {
-      const first = valid[0]!;
-      return { output: first.c, validation: first.v };
+    const scores = await opts.selfConsistency.ranker.rank(candidates, { validations });
+    let bestIdx = 0;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < candidates.length; i++) {
+      const s = scores[i] ?? Number.POSITIVE_INFINITY;
+      if (s < bestScore) {
+        bestScore = s;
+        bestIdx = i;
+      }
     }
-    const firstWithErr = candidates[0] ?? "";
-    return { output: firstWithErr, validation: opts.validator.validate(firstWithErr) };
+    return { output: candidates[bestIdx] ?? "", validation: validations[bestIdx] };
   }
 
   // Default: first-valid-wins.
-  for (const c of candidates) {
-    const v = opts.validator.validate(c);
-    if (v.ok) return { output: c, validation: v };
+  for (let i = 0; i < candidates.length; i++) {
+    if (validations[i]?.ok) return { output: candidates[i] ?? "", validation: validations[i] };
   }
-  const fallback = candidates[0] ?? "";
-  return { output: fallback, validation: opts.validator.validate(fallback) };
+  return { output: candidates[0] ?? "", validation: validations[0] };
 }

--- a/src/rankers/grammar.ts
+++ b/src/rankers/grammar.ts
@@ -1,0 +1,44 @@
+import type { Ranker, ValidationResult } from "../types.js";
+
+/**
+ * Best-of-N ranker that prefers (a) fully-valid candidates, then (b) candidates
+ * that progressed further before the validator gave up.
+ *
+ * Score (lower = better):
+ *   - validation.ok          → 0          (always best)
+ *   - !ok with errorOffset   → max(1, len - errorOffset)
+ *   - !ok without offset     → len        (treat as failure at position 0)
+ *   - no validation supplied → len        (fallback: prefer shorter)
+ *
+ * The intent: when N small-LLM samples all miss the grammar, the closest
+ * miss is still the most useful one to feed into retry-with-feedback (the
+ * error message that comes back from it will be the most specific).
+ *
+ * Use by passing through generate():
+ *
+ *   generate({
+ *     ...,
+ *     selfConsistency: { n: 5, ranker: new GrammarAwareRanker() },
+ *   });
+ *
+ * Requires a {@link Validator} on the same generate() call so the ranker
+ * receives validations via `context`. Without a validator the ranker
+ * degrades to a length-only score.
+ */
+export class GrammarAwareRanker implements Ranker {
+  readonly id = "grammar-aware";
+
+  async rank(
+    candidates: string[],
+    context?: { validations?: ValidationResult[] },
+  ): Promise<number[]> {
+    const validations = context?.validations;
+    return candidates.map((c, i) => {
+      const v = validations?.[i];
+      if (!v) return c.length;
+      if (v.ok) return 0;
+      const offset = typeof v.errorOffset === "number" ? v.errorOffset : 0;
+      return Math.max(1, c.length - offset);
+    });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,17 @@ export interface LLMAdapter {
 /** Result of validating one candidate output. */
 export type ValidationResult =
   | { ok: true; ast?: unknown }
-  | { ok: false; error: string };
+  | {
+      ok: false;
+      error: string;
+      /**
+       * Optional character offset in the source where parsing failed.
+       * Validators that can report this enable {@link GrammarAwareRanker} to
+       * prefer candidates that progressed further before failing — useful when
+       * none of the N candidates fully validate but one is "closer".
+       */
+      errorOffset?: number;
+    };
 
 /** Pluggable validator. Sync because parsers are typically fast and pure. */
 export interface Validator {
@@ -79,10 +89,17 @@ export interface Validator {
  * Lower score = better (consistent with "loss"-style semantics).
  * If absent, noroshi uses majority-vote-by-validation: pick the first
  * candidate that passes the validator.
+ *
+ * Rankers receive validation results when a {@link Validator} is configured,
+ * so they can score candidates relative to grammar progress without
+ * re-running the validator.
  */
 export interface Ranker {
   readonly id: string;
-  rank(candidates: string[]): Promise<number[]>;
+  rank(
+    candidates: string[],
+    context?: { validations?: ValidationResult[] },
+  ): Promise<number[]>;
 }
 
 /** Options for a single generation. */


### PR DESCRIPTION
Implements the **next-step "B"** from the [research spike](https://github.com/velocitylabo/noroshi/issues): grammar-aware best-of-N reranking to close the small-LLM 1-shot miss gap, while staying logit-free.

## Problem

When `selfConsistency.n > 1` and none of the N candidates fully validates, the old "first-valid wins" picker silently degraded to "first candidate wins" — the rest of the self-consistency signal was thrown away. The error feedback fed into the retry loop was therefore whichever sample happened to be sampled first, not whichever sample got closest to a valid program.

## Approach

- `ValidationResult` gains an optional `errorOffset` so a validator can report **how far it parsed** before giving up.
- `Ranker.rank` gains a `context?: { validations }` parameter so a ranker can score off that progress without re-parsing.
- `GrammarAwareRanker` (new) scores `valid → 0`, else `max(1, len - errorOffset)` — lower wins, so:
  - any fully-valid candidate beats every invalid one;
  - among invalid candidates, the deepest parse beats a shallow one.
- The picker (`src/noroshi.ts::pick`) is now async, threads validations through, and the out-of-retries return surfaces the picked output (was dropping the ranker's choice into `lastCandidates[0]`).

## Why this is worth doing now

- Directly attacks noroshi's biggest weakness: **small models (1B-3B) frequently miss on the first try**.
- Stays inside the prompt-side contract (no logit access required) so every adapter — `FetchAdapter`, `WebLLMAdapter`, future `ChromePromptAdapter` — gets the benefit equally.
- The deepest-failed-parse heuristic feeds the retry loop the most specific error message, which compounds with `retry.includeErrorInPrompt` — basically validity-aware sampling in the spirit of CRANE / GAD without needing constrained decoding.

## Tests

New suite `test-ranker.ts` (6 cases):

- Direct `rank()` ordering: valid (0) < deep-fail (1) < shallow-fail (24).
- End-to-end through `generate()`:
  - all 3 candidates invalid → deepest parse wins
  - mixed set → valid candidate wins regardless of position
  - no-ranker baseline → first-valid still wins (regression)

Combined with the existing suites (`test.ts` 9 / `test-fetch.ts` 8 / `test-safety.ts` 15), `npm test` now runs **38 assertions**, all green locally and on Node 20 + 22 (waiting on CI).

## Files

- `src/types.ts` — `ValidationResult.errorOffset?`, `Ranker.rank(..., context?)`
- `src/rankers/grammar.ts` (new) — `GrammarAwareRanker`
- `src/index.ts` — exports `GrammarAwareRanker`
- `src/noroshi.ts` — async pick, `lastOutput` fallback fix
- `examples/creative-coding-p5js/validator.ts` — lex + parser emit `errorOffset`
- `examples/creative-coding-p5js/harness.mjs` — mirrors the above for the browser path
- `examples/creative-coding-p5js/test-ranker.ts` (new) — 6 cases
- `package.json` — `npm test` runs the new suite alongside the others