### PR TITLE
Multi-model bench: noroshi pipeline vs model selection on small LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,20 @@ A WebLLM-driven browser example (with grammar injection, retry-with-feedback, an
 
 ## Benchmark — small LLM × novel DSL
 
-Headline result: a **1.5B-parameter on-device model** (Qwen2.5-1.5B-Instruct via local Ollama) drives noroshi from **0% to 85% valid output** on 20 novel creative-coding tasks without any fine-tuning.
+Headline result: a **1.5B-parameter on-device model** (Qwen2.5-1.5B-Instruct via local Ollama) drives noroshi from **0% to 85% valid output** on 20 novel creative-coding tasks — no fine-tuning, no logit-level constrained decoding.
 
-| Ablation | Valid | Success rate |
-|---|---:|---:|
-| baseline (task only) | 0/20 | **0%** |
-| + BNF grammar in prompt | 1/20 | **5%** |
-| + few-shot examples | 11/20 | **55%** |
-| + retry-with-feedback (×3) | 15/20 | **75%** |
-| + best-of-3 with `GrammarAwareRanker` | 17/20 | **85%** |
+| Model | Size | baseline | +grammar | +few-shot | +retry | **+rerank** |
+|---|---:|---:|---:|---:|---:|---:|
+| `qwen2.5:1.5b` | 0.99 GB | 0% | 5% | 55% | 75% | **85%** |
+| `gemma2:2b`    | 1.6 GB  | 0% | 10% | 30% | 45% | **75%** |
+| `llama3.2:1b`  | 1.3 GB  | 0% | 0% | 0% | 0% | **0%** |
 
-Each row is the same noroshi pipeline with one additional component turned on, evaluated by the same post-hoc validator. Full methodology, per-row commentary, and the JSON output are under [`examples/creative-coding-p5js/bench/`](https://github.com/velocitylabo/noroshi/tree/main/examples/creative-coding-p5js/bench).
+Two takeaways:
+
+1. **The pipeline is roughly model-agnostic** — `qwen` and `gemma` ride the same ablation curve, the latter at lower magnitudes.
+2. **Model selection still dominates** — `llama3.2:1b` flatlines because it consistently echoes the grammar's leading rule (`start: block+` → literal token `start` at offset 0), and retry/rerank can't shake it loose.
+
+Full methodology, per-row commentary, latency tables, and raw JSON: [`examples/creative-coding-p5js/bench/`](https://github.com/velocitylabo/noroshi/tree/main/examples/creative-coding-p5js/bench).
 
 ## Why
 

--- a/examples/creative-coding-p5js/bench/README.md
+++ b/examples/creative-coding-p5js/bench/README.md
@@ -49,25 +49,44 @@ Expected wall time on a single 1.5B model on a CUDA RTX 2060 ≈ **5-15 minutes*
 
 ## Results
 
-Frozen run, 2026-05-22, model `qwen2.5:1.5b` via local Ollama on an RTX 2060 Mobile. Raw JSON: [`results-qwen2.5_1.5b.json`](./results-qwen2.5_1.5b.json).
+Frozen runs, 2026-05-22, via local Ollama on an RTX 2060 Mobile (6 GB).
 
-| Ablation | Valid | Success rate | Avg attempts | Avg latency |
-|---|---:|---:|---:|---:|
-| `baseline` | 0/20 | **0%** | 1.0 | 492 ms |
-| `grammar-only` | 1/20 | **5%** | 1.0 | 645 ms |
-| `+few-shot` | 11/20 | **55%** | 1.0 | 443 ms |
-| `+retry` | 15/20 | **75%** | 1.8 | 727 ms |
-| `+rerank` | 17/20 | **85%** | 4.7 | 1,539 ms |
+### Success rate × model × ablation
 
-### What each row buys
+| Model | Size | baseline | +grammar | +few-shot | +retry | **+rerank** |
+|---|---:|---:|---:|---:|---:|---:|
+| `qwen2.5:1.5b`  | 0.99 GB |  0% |  5% | **55%** | **75%** | **85%** |
+| `gemma2:2b`     | 1.6 GB  |  0% | 10% |  30% |  45% | **75%** |
+| `llama3.2:1b`   | 1.3 GB  |  0% |  0% |   0% |   0% |  **0%** |
 
-- **0 → 5%** with grammar alone: the 1.5B model can't even guess the surface from a plain task description; injecting the BNF nudges it slightly.
-- **5 → 55%** with few-shot examples: the biggest single jump — derivation-first examples teach the model the DSL shape in one prompt.
-- **55 → 75%** with retry-with-feedback (×3): the validator's error message, fed back into the next prompt, recovers 4 of the remaining 9 misses.
-- **75 → 85%** with best-of-3 + GrammarAwareRanker: when retry alone can't close the gap, sampling N=3 and picking the deepest-parse candidate (or any valid one) clears 2 more — the rerank is what survives when retry's fix doesn't generalise.
+Raw JSON: [`results-qwen2.5_1.5b.json`](./results-qwen2.5_1.5b.json), [`results-gemma2_2b.json`](./results-gemma2_2b.json), [`results-llama3.2_1b.json`](./results-llama3.2_1b.json).
+
+### Latency (avg ms / task)
+
+| Model | baseline | +grammar | +few-shot | +retry | +rerank |
+|---|---:|---:|---:|---:|---:|
+| `qwen2.5:1.5b`  |  492 |  645 |   443 |   727 |  1,539 |
+| `gemma2:2b`     | 2,193 | 1,646 |   947 | 3,175 |  7,244 |
+| `llama3.2:1b`   | 1,776 | 2,121 | 2,095 | 6,157 | 17,839 |
+
+### Per-row reading (qwen2.5:1.5b — best-performing model)
+
+- **0 → 5%** with grammar alone: a 1.5B model can't guess the DSL surface from the task description; the BNF nudges it slightly.
+- **5 → 55%** with few-shot examples: biggest single jump — derivation-first examples teach the DSL shape in one prompt.
+- **55 → 75%** with retry-with-feedback (×3): the validator's error, fed back into the next prompt, recovers 4 of the remaining 9 misses.
+- **75 → 85%** with best-of-3 + `GrammarAwareRanker`: when retry alone can't close the gap, sampling N=3 and picking the deepest-parse candidate clears 2 more.
+
+### What the multi-model row teaches us
+
+The two extra models split clean into "the pipeline amplifies what's there" vs "there's nothing to amplify":
+
+- **`gemma2:2b` (75% at +rerank)** rides the same ablation curve as `qwen2.5:1.5b`, just lower and slower — bigger model, more parameters spent on irrelevant capability, similar shape.
+- **`llama3.2:1b` (0% everywhere)** flatlines. Inspection shows it greedily echoes the leading rule of the grammar (`start: block+` → output starts with the literal token `start` → lex fails at offset 0). retry-with-feedback doesn't shake it loose; best-of-3 doesn't either, because all N samples make the same mistake. **noroshi can't amplify a model that doesn't have the DSL surface in its prior.**
+
+This is the headline finding of the multi-model run: the pipeline is roughly model-agnostic, but **model selection still dominates**. For a creative-coding application targeting an on-device 1-2B model, default to Qwen-2.5 family unless there's a hard reason not to.
 
 ### Caveats
 
-- Single model (`qwen2.5:1.5b`, ~1B effective). A separate run on `llama3.2:1b`, `gemma-2-2b-it`, etc. would let us factor model-vs-pipeline.
-- This is a **novel** DSL — the comparison that matters is column-vs-column (ablations on the same prompt), not against Wang et al.'s SMCalFlow / GeoQuery numbers.
-- `+rerank` more than triples latency (~440 → ~1540 ms) for +10 pt. That trade is right when wall time is below the human-noticing threshold (typing pause), wrong when you're rendering on every keystroke.
+- This is a **novel** DSL — the comparison that matters is column-vs-column (ablations on the same prompt) and row-vs-row (model-vs-model on the same prompt), not against Wang et al.'s SMCalFlow / GeoQuery / PDDL numbers (very different domain difficulty and model class).
+- `+rerank` triples to 10× latency for +10-30 pt on the models that respond at all. Right when wall time is below the human-noticing threshold (one-shot prompt), wrong for per-keystroke interactivity.
+- The `llama3.2:1b` 0% may be improvable — possibly with a different grammar header (no `start:` rule name), heavier few-shot derivation labelling, or just a bigger Llama-family model. Not worth optimising before validating with users which model they actually plan to ship.

--- a/examples/creative-coding-p5js/bench/results-gemma2_2b.json
+++ b/examples/creative-coding-p5js/bench/results-gemma2_2b.json
@@ -1,0 +1,970 @@
+{
+  "model": "gemma2:2b",
+  "endpoint": "http://localhost:11434/v1",
+  "timestamp": "2026-05-22T08:43:17.469Z",
+  "taskCount": 20,
+  "ablations": [
+    {
+      "name": "baseline",
+      "description": "task only, no grammar, no few-shot, no validator",
+      "useGrammar": false,
+      "useFewShot": false,
+      "useValidator": false,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "grammar-only",
+      "description": "BNF grammar injected, no few-shot",
+      "useGrammar": true,
+      "useFewShot": false,
+      "useValidator": false,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+few-shot",
+      "description": "grammar + few-shot examples (noroshi default, 1 attempt)",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+retry",
+      "description": "grammar + few-shot + retry-with-feedback up to 3 attempts",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 3,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+rerank",
+      "description": "grammar + few-shot + retry + best-of-3 with GrammarAwareRanker",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 3,
+      "selfConsistencyN": 3,
+      "useRanker": true
+    }
+  ],
+  "summary": [
+    {
+      "name": "baseline",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 1,
+      "avgLatencyMs": 2192.6
+    },
+    {
+      "name": "grammar-only",
+      "passed": 2,
+      "total": 20,
+      "successRate": 0.1,
+      "avgAttempts": 1,
+      "avgLatencyMs": 1645.85
+    },
+    {
+      "name": "+few-shot",
+      "passed": 6,
+      "total": 20,
+      "successRate": 0.3,
+      "avgAttempts": 1,
+      "avgLatencyMs": 947
+    },
+    {
+      "name": "+retry",
+      "passed": 9,
+      "total": 20,
+      "successRate": 0.45,
+      "avgAttempts": 2.4,
+      "avgLatencyMs": 3175.2
+    },
+    {
+      "name": "+rerank",
+      "passed": 15,
+      "total": 20,
+      "successRate": 0.75,
+      "avgAttempts": 5.7,
+      "avgLatencyMs": 7244.05
+    }
+  ],
+  "results": [
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 33682,
+      "outputPreview": "<canvas> fill:black stroke:white circle:100 100 100",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 788,
+      "outputPreview": "setup() {\n  background(0);\n  circle(width/2, height/2, 50);\n}",
+      "error": "unexpected character \";\" at offset 25"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 565,
+      "outputPreview": "background black\nfill white\ncircle w / 2 h / 2 50"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 623,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill white\n  circle w / 2 h / 2 50\n}"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1132,
+      "outputPreview": "background black\nfill white\ncircle w / 2 h / 2 50"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 344,
+      "outputPreview": "<canvas style=\"background-color:green\"></canvas>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "grammar-only",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 440,
+      "outputPreview": "background green"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 349,
+      "outputPreview": "background green"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 225,
+      "outputPreview": "background green"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 469,
+      "outputPreview": "background green"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 589,
+      "outputPreview": "<draw> <color=\"red\"> <shape> <rect> <corner x=\"0\" y=\"0\"/> </shape> </color>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 775,
+      "outputPreview": "setup() {\n  rect(10, 10, 50, 50);\n}",
+      "error": "unexpected character \";\" at offset 32"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 722,
+      "outputPreview": "setup {\n  background white\n  fill red\n  rect 0 0 100 100 \n}"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 504,
+      "outputPreview": "setup {\n  background white\n  fill red\n  square 0 0 50\n}"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1411,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill red\n  square 0 0 50\n}"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 517,
+      "outputPreview": "<line x=\"0\" y=\"canvas_height/2\" width=\"canvas_width\" color=\"blue\"/>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "grammar-only",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 639,
+      "outputPreview": "rect 100 50 200 10"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 496,
+      "outputPreview": "line w / 2 h/2 100",
+      "error": "expected expression, got end of input"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 1356,
+      "outputPreview": "tick {\n  background black\n  fill blue\n  line w / 2 h / 2 50\n}",
+      "error": "expected number, variable, function call, or \"(...)\" at offset 60, got \"}\""
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 2834,
+      "outputPreview": "tick {\n  background black\n  fill blue\n  line w / 2 h / 2 \n}",
+      "error": "expected number, variable, function call, or \"(...)\" at offset 58, got \"}\""
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 364,
+      "outputPreview": "<circle color=\"purple\" position=\"bottom-right\">",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 686,
+      "outputPreview": "background red\ncircle 100 100 50 50 purple",
+      "error": "expected a statement keyword at offset 33, got \"50\""
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 531,
+      "outputPreview": "fill purple\ncircle w / 2 h / 2 10"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 458,
+      "outputPreview": "background black\nfill purple\ncircle w / 2 h / 2 10"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1097,
+      "outputPreview": "fill purple\ncircle w / 2 h / 2 10"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 460,
+      "outputPreview": "<circle color=\"pink\" /> <circle color=\"pink\" /> <circle color=\"pink\" />",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2957,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = 640;\n  h = 480;\n  mx = 0;\n  my = 0;\n  i = 0;\n}\n\ntick() {\n  background(255, 200, 250);\n",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1250,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (pink), circle expr expr expr\nOutput",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5668,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (pink) circle expr expr expr \nOutput",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 19414,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (pink) circle expr expr expr \nOutput",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 593,
+      "outputPreview": "<background> <color>white</color> \n<shape> <color>green</color> <rect> </rect>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 497,
+      "outputPreview": "background white\nsquare green",
+      "error": "expected number, variable, function call, or \"(...)\" at offset 24, got \"green\""
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 598,
+      "outputPreview": "background white\nfill green\nsquare w / 2 h / 2 50"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 450,
+      "outputPreview": "background white\nfill green\nsquare w / 2 h / 2 50"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1137,
+      "outputPreview": "background white\nfill green\nsquare w / 2 h / 2 50"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 417,
+      "outputPreview": "[purple-square]\n    [purple-square]",
+      "error": "unexpected character \"[\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1351,
+      "outputPreview": "setup() {\n  background(255, 0, 255);\n  rect(100, 100, 100, 100);\n  rect(200, 100, 100, 100);\n}",
+      "error": "unexpected character \";\" at offset 35"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 999,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill purple\n  square 0 0 100 100\n  square 100 0 100 100\n}",
+      "error": "expected a statement keyword at offset 67, got \"100\""
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 2972,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (purple), square expr expr expr\nOutp",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 9,
+      "latencyMs": 12819,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill purple\n  square 20 20 40\n  square 20 20 40\n}"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 593,
+      "outputPreview": "<circle color=\"red\" fill-color=\"red\"/> <rect color=\"blue\" stroke-width=\"0\" fill-color=\"blue\"/>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 971,
+      "outputPreview": "setup() {\n  background(color(\"blue\"));\n  fill(color(\"red\"));\n  circle(100, 100, 50);\n}",
+      "error": "unknown identifier \"color\" at offset 23"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 3766,
+      "outputPreview": "```\nshape_stmt: \"circle\" expr expr expr             // x y radius\n          | \"square\" expr expr expr             // x y",
+      "error": "unexpected character \"`\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 2012,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 4576,
+      "outputPreview": "fill red\nrect w / 2 h / 2 50 100"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 902,
+      "outputPreview": "circle {color: \"orange\"} \n{position: [0, 0]} \n{radius: 5} \n{x_offset: 1} \n{y_offset: 0}",
+      "error": "unknown identifier \"color\" at offset 8"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2872,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = 640;\n  h = 480;\n  mx = 0;\n  my = 0;\n  i = 0;\n\n  background(255, 165, 0);\n}\n\ntick() {\n ",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1127,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×5)\nshape_stmt → fill color (orange), circle expr expr expr\nOutp",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 8368,
+      "outputPreview": "```\nstart → block+\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"ti",
+      "error": "unexpected character \"`\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 25085,
+      "outputPreview": "```\nstart → block+\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"ti",
+      "error": "unexpected character \"`\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 335,
+      "outputPreview": "[yellow dot] * 10",
+      "error": "unexpected character \"[\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2257,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = 500;\n  h = 500;\n  mx = 0;\n  my = 0;\n  i = 0;\n  background(255);\n}\n\ntick() {\n  for (i =",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 841,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (yellow), dot expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 2761,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color yellow, dot expr expr expr\nOutput:\nb",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 12665,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (yellow), dot expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 760,
+      "outputPreview": "[  ]\n     [  ]\n     [  ]\n     [  ]\n     [  ]\n     [  ]\n     [  ]\n     [  ]",
+      "error": "unexpected character \"[\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 3070,
+      "outputPreview": "setup() {\n  background(255);\n  rect(100, 100, 100, 100);\n  rect(200, 100, 100, 100);\n  rect(300, 100, 100, 100);\n  rect(",
+      "error": "unexpected character \";\" at offset 27"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 739,
+      "outputPreview": "block → bg_stmt, repeat 8 { square (i * 40 + 20) h/2 15 }",
+      "error": "unknown identifier \"block\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5832,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (blue), square (i * 40 + 20) h/2 40\n",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 4670,
+      "outputPreview": "background black\nfill blue\nrepeat 8 { square 0 h/2 40 }"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 658,
+      "outputPreview": "[circle] {6} [circle] {green} [circle] {small} [circle] {near} [circle] {top}",
+      "error": "unexpected character \"[\" at offset 0"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2461,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = 640;\n  h = 480;\n  mx = 320;\n  my = 240;\n  i = 0;\n  background(192, 192, 192);\n  for (i",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+few-shot",
+      "ok": true,
+      "attempts": 1,
+      "latencyMs": 912,
+      "outputPreview": "setup {\n  background white\n}\ntick {\n  fill green\n  repeat 6 { circle i * 40 + 20 h/2 15 }\n}"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 2,
+      "latencyMs": 1890,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill green\n  repeat 6 { circle (i * 40 + 20) h/2 15 }\n}"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 6,
+      "latencyMs": 4639,
+      "outputPreview": "background white\nfill green\nrepeat 6 { circle (i * 40) h/2 15 }"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 443,
+      "outputPreview": "circle {\n  position: center;\n  velocity: 1;\n}",
+      "error": "unknown identifier \"position\" at offset 11"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2069,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = windowWidth();\n  h = windowHeight();\n  mx = w / 2;\n  my = h / 2;\n  i = 0;\n}\n\ntick() {\n",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 865,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5519,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr\nOutput:",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 11901,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1078,
+      "outputPreview": "{ \n  \"type\": \"square\", \n  \"properties\": {\n    \"center\": {\n      \"growth_rate\": 0.1, \n      \"shrink_rate\": 0.1\n    }\n  },",
+      "error": "unexpected character \"\"\" at offset 5"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1783,
+      "outputPreview": "setup() {\n  size(400, 400);\n  background(255);\n}\ntick() {\n  fill(255, 0, 0);\n  rect(100, 100, 100, 100);\n  push();\n  tra",
+      "error": "unknown identifier \"size\" at offset 12"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1063,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (pink), square (abs(t) * 10 + w/2) h",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 2384,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), square expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 6,
+      "latencyMs": 4129,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill blue\n  square w / 2 h / 2 100 \n}"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 428,
+      "outputPreview": "<circle> <color=\"pink\"> <center> </center> </color>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1046,
+      "outputPreview": "setup() {\n  background(255, 192, 208);\n  fill(\"pink\");\n  circle(width/2, height/2, 50);\n}",
+      "error": "unexpected character \";\" at offset 37"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 996,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (pink), circle w / 2 h / 2 50",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 2,
+      "latencyMs": 1545,
+      "outputPreview": "tick {\n  background black\n  fill pink\n  circle w / 2 h / 2 50\n}"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1987,
+      "outputPreview": "tick {\n  background white\n  fill pink\n  circle w / 2 h / 2 50\n}"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 393,
+      "outputPreview": "dot {\n  position: mouse_position\n}",
+      "error": "unknown identifier \"dot\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1842,
+      "outputPreview": "// green dot that follows the mouse\n{\n  setup: function() {\n    background(255);\n  }\n  tick: function() {\n    mx = mouse",
+      "error": "unexpected character \":\" at offset 45"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 618,
+      "outputPreview": "tick {\n  background white\n  fill green\n  dot mx my 10\n}",
+      "error": "unknown identifier \"dot\" at offset 41"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 1450,
+      "outputPreview": "tick {\n  background black\n  fill green\n  circle mx my 5\n}"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 9,
+      "latencyMs": 3616,
+      "outputPreview": "tick {\n  background black\n  fill green\n  circle mx my 5 \n}"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 346,
+      "outputPreview": "<circle color=\"red\"  position=\"mouse\">",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1747,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = 500;\n  h = 500;\n  mx = 0;\n  my = 0;\n  i = 0;\n}\n\ntick() {\n  background(255);\n  fill(\"re",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 850,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5619,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr\nOutput:",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 6,
+      "latencyMs": 9845,
+      "outputPreview": "tick {\n  background black\n  fill red\n  circle mx my 30\n}"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 463,
+      "outputPreview": "circle {\n  position: { x: 0, y: 0 }\n}",
+      "error": "unknown identifier \"position\" at offset 11"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2253,
+      "outputPreview": "setup() {\n  t = 0;\n  f = 0;\n  w = windowWidth();\n  h = windowHeight();\n  mx = mouseX();\n  my = mouseY();\n  i = 0;\n}\n\ntic",
+      "error": "unexpected character \"=\" at offset 14"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 830,
+      "outputPreview": "start → block\nblock → stmt\nstmt → bg_stmt | shape_stmt (×2)\nshape_stmt → fill color (red), circle expr expr expr",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+retry",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 5359,
+      "outputPreview": "background black\nfill red\ncircle w / 2 h / 2 50"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 6,
+      "latencyMs": 16460,
+      "outputPreview": "setup {\n  background black\n}\ntick {\n  fill red\n  circle w / 2 h / 2 50\n}"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 487,
+      "outputPreview": "background: {\n  color_mode: \"black-and-white\"\n}",
+      "error": "unexpected character \":\" at offset 10"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2413,
+      "outputPreview": "background(\"black\") {\n  setup()\n  {\n    t = 0;\n    f = 0;\n    w = 100;\n    h = 100;\n    mx = 50;\n    my = 50;\n    i = 0;",
+      "error": "unexpected character \"\"\" at offset 11"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 823,
+      "outputPreview": "start → block\nblock → bg_stmt\n    | repeat_stmt\n    { background black, fill white }\n    { background white, fill black ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 8509,
+      "outputPreview": "```\nstart → block+\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"ti",
+      "error": "unexpected character \"`\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+rerank",
+      "ok": true,
+      "attempts": 3,
+      "latencyMs": 4995,
+      "outputPreview": "background black\nrepeat 10 {\n  background white\n  background black\n}"
+    }
+  ]
+}

--- a/examples/creative-coding-p5js/bench/results-llama3.2_1b.json
+++ b/examples/creative-coding-p5js/bench/results-llama3.2_1b.json
@@ -1,0 +1,1002 @@
+{
+  "model": "llama3.2:1b",
+  "endpoint": "http://localhost:11434/v1",
+  "timestamp": "2026-05-22T08:38:12.737Z",
+  "taskCount": 20,
+  "ablations": [
+    {
+      "name": "baseline",
+      "description": "task only, no grammar, no few-shot, no validator",
+      "useGrammar": false,
+      "useFewShot": false,
+      "useValidator": false,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "grammar-only",
+      "description": "BNF grammar injected, no few-shot",
+      "useGrammar": true,
+      "useFewShot": false,
+      "useValidator": false,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+few-shot",
+      "description": "grammar + few-shot examples (noroshi default, 1 attempt)",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 0,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+retry",
+      "description": "grammar + few-shot + retry-with-feedback up to 3 attempts",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 3,
+      "selfConsistencyN": 1,
+      "useRanker": false
+    },
+    {
+      "name": "+rerank",
+      "description": "grammar + few-shot + retry + best-of-3 with GrammarAwareRanker",
+      "useGrammar": true,
+      "useFewShot": true,
+      "useValidator": true,
+      "retry": 3,
+      "selfConsistencyN": 3,
+      "useRanker": true
+    }
+  ],
+  "summary": [
+    {
+      "name": "baseline",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 1,
+      "avgLatencyMs": 1775.95
+    },
+    {
+      "name": "grammar-only",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 1,
+      "avgLatencyMs": 2120.55
+    },
+    {
+      "name": "+few-shot",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 1,
+      "avgLatencyMs": 2094.55
+    },
+    {
+      "name": "+retry",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 3,
+      "avgLatencyMs": 6157.1
+    },
+    {
+      "name": "+rerank",
+      "passed": 0,
+      "total": 20,
+      "successRate": 0,
+      "avgAttempts": 9,
+      "avgLatencyMs": 17839.15
+    }
+  ],
+  "results": [
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 28747,
+      "outputPreview": "draw_circle() -> canvas white circle\n  canvas = black\n  draw_circle(canvas, white, center)",
+      "error": "unknown identifier \"draw_circle\" at offset 0"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1963,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1944,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5698,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a single white circle in the middle of a black canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 16574,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 221,
+      "outputPreview": "<canvas style=\"background-color: green;\"></canvas>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2002,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2037,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5884,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Fill the canvas with green.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 16788,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 162,
+      "outputPreview": "RED SQUARE\n```",
+      "error": "unknown identifier \"RED\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2012,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1984,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5912,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a red square at the top-left corner.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17257,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 240,
+      "outputPreview": "Line { type = Horizontal; color = Blue; }",
+      "error": "unknown identifier \"Line\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2042,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2009,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5943,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a horizontal blue line across the middle of the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17445,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 176,
+      "outputPreview": "draw_circle_bottom_right()",
+      "error": "unknown identifier \"draw_circle_bottom_right\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2065,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2050,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 5978,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Draw a small purple circle at the bottom-right.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17463,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 600,
+      "outputPreview": "<circle> <pink> <x=0..5> <y=0..2> / <circle> <pink> <x=6..10> <y=0..2> / <circle> <pink> <x=11..15> <y=0..2>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2094,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2052,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6089,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Three pink circles in a horizontal row.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17712,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 280,
+      "outputPreview": "\\033[38;5;32m\\033[90m\\033[0m",
+      "error": "unexpected character \"\\\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2095,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2071,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6116,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A white background with a green square in the center.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17728,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 511,
+      "outputPreview": "<rect x=\"0\" y=\"0\" width=\"100%\" height=\"50%\" fill=\"#800080\" /> <rect x=\"10\" y=\"20\" width=\"80%\" height=\"30%\" fill=\"#800080",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2140,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2069,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6127,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Two purple squares side by side at the top.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17908,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 306,
+      "outputPreview": "<rect><circle><color>red</color></circle><rect><color>blue</color></rect>",
+      "error": "unexpected character \"<\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2106,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2082,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6120,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle inside a blue rectangle.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17931,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 159,
+      "outputPreview": "Five orange circles",
+      "error": "unknown identifier \"Five\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2137,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2097,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6231,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Five orange circles spread out horizontally across the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18095,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 201,
+      "outputPreview": "Ten yellow dots arranged in a row.",
+      "error": "unknown identifier \"Ten\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2118,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2137,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6243,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Ten yellow dots arranged in a row.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18045,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 193,
+      "outputPreview": "Eight blue squares stacked vertically.",
+      "error": "unknown identifier \"Eight\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2130,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2121,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6224,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Eight blue squares stacked vertically.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18030,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 261,
+      "outputPreview": "{green|small} {circle|6} {near|top}",
+      "error": "unexpected character \"|\" at offset 6"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2137,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2183,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6188,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Six small green circles in a row near the top.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18088,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 340,
+      "outputPreview": "circle { move { left { x = x - 10; } right { x = x + 10; } } }",
+      "error": "unknown identifier \"move\" at offset 9"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2179,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2168,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6349,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that moves left and right across the middle of the canvas.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 17978,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 851,
+      "outputPreview": "Square\n  | Square\n  |-- Grow\n  |    |-- Center\n  |    | Square\n  |    |   |-- Shrink\n  |    |   |-- Center\n  |    |\n  | ",
+      "error": "unknown identifier \"Square\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2188,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2106,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6387,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A square that grows and shrinks at the center over time.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18237,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 269,
+      "outputPreview": "PulsingPinkCircle: PulsingPinkCircle{ Pink Circle }*",
+      "error": "unknown identifier \"PulsingPinkCircle\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2155,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2150,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6249,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A pulsing pink circle in the middle.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18265,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 174,
+      "outputPreview": "Green Dot Follows Mouse",
+      "error": "unknown identifier \"Green\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2157,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2152,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6295,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A green dot that follows the mouse.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18226,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 210,
+      "outputPreview": "RED CIRCLE TRACKS MOUSE POSITION",
+      "error": "unknown identifier \"RED\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2178,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2177,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6393,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A red circle that tracks the mouse position.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18271,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 240,
+      "outputPreview": "Circle { orbiting around Canvas }",
+      "error": "unknown identifier \"Circle\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2199,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2143,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6439,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "A circle that orbits around the center of the canvas over time.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18441,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "baseline",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 1378,
+      "outputPreview": "Background: \n  Flash: \n    Black: \n      Time: \n        Interval: \n          Milliseconds: \n            Number: \n       ",
+      "error": "unknown identifier \"Background\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "grammar-only",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2314,
+      "outputPreview": "start: block+\n\nblock: setup_block\n     | tick_block\n     | stmt\n\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\" ",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+few-shot",
+      "ok": false,
+      "attempts": 1,
+      "latencyMs": 2159,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+retry",
+      "ok": false,
+      "attempts": 3,
+      "latencyMs": 6277,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    },
+    {
+      "task": "Background that flashes between black and white over time.",
+      "ablation": "+rerank",
+      "ok": false,
+      "attempts": 9,
+      "latencyMs": 18301,
+      "outputPreview": "start: block+\nblock: setup_block | tick_block | stmt\nsetup_block: \"setup\" \"{\" stmt* \"}\"\ntick_block:  \"tick\"  \"{\" stmt* \"",
+      "error": "unknown identifier \"start\" at offset 0"
+    }
+  ]
+}


### PR DESCRIPTION
Adds two more frozen bench runs alongside the existing `qwen2.5:1.5b` row from PR #4 and rewrites the bench tables around the cross-model comparison.

## Result table

Same 5-ablation × 20-task bench, three on-device-class models via local Ollama on an RTX 2060 Mobile:

| Model | Size | baseline | +grammar | +few-shot | +retry | **+rerank** | +rerank ms |
|---|---:|---:|---:|---:|---:|---:|---:|
| `qwen2.5:1.5b` | 0.99 GB | 0% | 5% | 55% | 75% | **85%** | 1,539 |
| `gemma2:2b`    | 1.6 GB  | 0% | 10% | 30% | 45% | **75%** | 7,244 |
| `llama3.2:1b`  | 1.3 GB  | 0% | 0% | 0% | 0% | **0%** | 17,839 |

## What it teaches

Two takeaways, both worth surfacing in the README:

1. **The pipeline itself is roughly model-agnostic.** `qwen` and `gemma` ride the same ablation curve shape — each additional component (grammar → few-shot → retry → rerank) buys success rate roughly in proportion. The pipeline isn't tuned to a specific model.

2. **Model selection still dominates.** `llama3.2:1b` flatlines at **0% in every cell**. Inspection of per-task error messages shows it consistently echoes the grammar's leading rule (`start: block+` → output begins with the literal token `start` → lex fails at offset 0). retry-with-feedback doesn't shake it loose; best-of-3 doesn't either, because all N samples make the same mistake. **noroshi can't amplify a model that doesn't have the DSL surface in its prior.**

Practical guidance derived from this: for a 1-2B on-device creative-coding target, default to the Qwen-2.5 family.

## Files

- `examples/creative-coding-p5js/bench/results-llama3.2_1b.json`, `results-gemma2_2b.json` — frozen JSON outputs, checked in so the README numbers are reproducible.
- `examples/creative-coding-p5js/bench/README.md` — now a three-model success table + three-model latency table + per-row reading on the best-performing model + a "what the multi-model row teaches us" section.
- `README.md` (root) — Benchmark section's table swaps from single-model to three-model.

## Not in scope (follow-ups)

- Rescue attempt on `llama3.2:1b` (different grammar header naming, heavier derivation labels, larger Llama-family model) — only worth doing if a user actually plans to ship Llama-class.
- Best-of-N sweep on the working models (N=5 / N=8) — diminishing returns likely, unmeasured.
- CRANE-style derivation/output delimiter split (option A from the research spike).