### PR TITLE
Add Consulting / commercial-use section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ The Wang et al. result: SFT-free, competitive with fine-tuned baselines on SMCal
 
 The `examples/` directory will host reference applications demonstrating `noroshi` for various DSLs (creative coding with p5.js, simplified SQL subsets, custom annotation languages, etc.).
 
+## Consulting / commercial use
+
+`noroshi` is MIT and that won't change. If you want help going further — designing a domain-specific grammar for your product, integrating noroshi into a closed-source codebase, or scoping a structured-output engagement on top of an on-device LLM — Velocity LABO takes paid work in that lane.
+
+- Email: [contact@velocitylabo.dev](mailto:contact@velocitylabo.dev)
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Adds a paid-work intake channel above the License section so readers arriving from a future blog post / HN submission have an obvious way to reach Velocity LABO for engagements that go beyond what an MIT library covers.

Live mailto: `contact@velocitylabo.dev`.

GitHub Sponsors (\`@velocitylabo\`) will be added as a second contact line in a follow-up commit once the Sponsors account is set up — that's a GitHub-UI-only operation, not in this PR.

Why now: the long-form blog post in branch \`docs/blog-grammar-prompting\` will go public on HN / Zenn within the next few weeks. The README is the first place an interested reader will land after the article, and without this section there is no surfaced path from "I read about noroshi" to "I want to talk about a project."

## Test plan

- [x] \`mailto:\` renders correctly on GitHub README
- [x] Section sits between Examples and License, where it's discoverable but not above-the-fold