### PR TITLE
Add GitHub Sponsors link to the Consulting / commercial-use section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The `examples/` directory will host reference applications demonstrating `norosh
 `noroshi` is MIT and that won't change. If you want help going further — designing a domain-specific grammar for your product, integrating noroshi into a closed-source codebase, or scoping a structured-output engagement on top of an on-device LLM — Velocity LABO takes paid work in that lane.
 
 - Email: [contact@velocitylabo.dev](mailto:contact@velocitylabo.dev)
+- Sponsor on GitHub: [github.com/sponsors/velocitylabo](https://github.com/sponsors/velocitylabo)
 
 ## License
 


### PR DESCRIPTION
Sponsors profile is now live at github.com/sponsors/velocitylabo with
two tiers (Coffee $5/mo, Supporter $20/mo, both listing-only — no
reward-fulfilment overhead on the maintainer side). The README link
gives readers arriving from the upcoming blog post a low-friction way
to back the OSS work without going through the consulting / email
channel.
